### PR TITLE
[codex] Require Google for new signups

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -48,4 +48,7 @@ REDIS_URL=redis://localhost:6379
 # POSTHOG (Optional - Product Analytics)
 # ===========================================
 # NEXT_PUBLIC_POSTHOG_KEY=phc_...
+# Use your managed reverse proxy in production, e.g. https://z.resumelm.com.
 # NEXT_PUBLIC_POSTHOG_HOST=https://us.i.posthog.com
+# Keep this pointed at the PostHog app host when using a reverse proxy.
+# NEXT_PUBLIC_POSTHOG_UI_HOST=https://us.posthog.com

--- a/src/app/auth/callback/route.ts
+++ b/src/app/auth/callback/route.ts
@@ -2,24 +2,40 @@
 import { createClient } from '@/utils/supabase/server'
 import { NextRequest, NextResponse } from 'next/server'
 
+function getSafeRedirectPath(path: string | null, fallback = '/') {
+  if (!path) return fallback
+  if (!path.startsWith('/')) return fallback
+  if (path.startsWith('//')) return fallback
+  return path
+}
+
 export async function GET(request: NextRequest) {
   const requestUrl = new URL(request.url)
   const code = requestUrl.searchParams.get('code')
   const next = requestUrl.searchParams.get('next')
 
-  if (code) {
-    // Ensure you pass cookies correctly. For App Router, it's a function.
-    const supabase = await createClient()
-    await supabase.auth.exchangeCodeForSession(code)
+  if (!code) {
+    const errorUrl = new URL('/auth/login', requestUrl.origin)
+    errorUrl.searchParams.set('error', 'auth_code_missing')
+    return NextResponse.redirect(errorUrl)
+  }
+
+  const supabase = await createClient()
+  const { error } = await supabase.auth.exchangeCodeForSession(code)
+
+  if (error) {
+    console.error('OAuth callback failed:', error.message)
+    const errorUrl = new URL('/auth/login', requestUrl.origin)
+    errorUrl.searchParams.set('error', 'auth_callback_failed')
+    return NextResponse.redirect(errorUrl)
   }
 
   // URL to redirect to after sign in process completes
   // If 'next' is provided and is a relative path, use it.
   // Otherwise, default to the root.
-  const redirectPath = (next && next.startsWith('/')) ? next : '/'
+  const redirectPath = getSafeRedirectPath(next)
   
   // Construct the full redirect URL
   return NextResponse.redirect(new URL(redirectPath, requestUrl.origin))
 } 
-
 

--- a/src/app/auth/login/actions.ts
+++ b/src/app/auth/login/actions.ts
@@ -8,6 +8,7 @@ import { loginSchema, signupSchema } from "@/lib/auth-schemas";
 import type { AuthFormState } from "@/components/auth/auth-form-state";
 import { AnalyticsEvents } from "@/lib/analytics/events";
 import { captureServerAnalyticsEvent } from "@/lib/analytics/server";
+import { getEmailSignupBlockedMessage, isEmailSignupAllowed } from "@/lib/auth-policy";
 
 // Auto-create Pro subscription for new users (for local development)
 const AUTO_PRO_SUBSCRIPTION = process.env.AUTO_PRO_SUBSCRIPTION === 'true';
@@ -17,7 +18,7 @@ interface AuthResult {
   error?: string;
 }
 
-interface GithubAuthResult extends AuthResult {
+interface OAuthAuthResult extends AuthResult {
   url?: string;
 }
 
@@ -56,6 +57,10 @@ export async function login(formData: FormData): Promise<AuthResult> {
 
 // Signup
 export async function signup(formData: FormData): Promise<AuthResult> {
+  if (!isEmailSignupAllowed()) {
+    return { success: false, error: getEmailSignupBlockedMessage() };
+  }
+
   const supabase = await createServiceClient();
 
   const data = {
@@ -142,6 +147,13 @@ export async function signupWithState(
   _previousState: AuthFormState,
   formData: FormData
 ): Promise<AuthFormState> {
+  if (!isEmailSignupAllowed()) {
+    return {
+      status: "error",
+      message: getEmailSignupBlockedMessage(),
+    };
+  }
+
   const parsedData = signupSchema.safeParse({
     name: formData.get('name'),
     email: formData.get('email'),
@@ -193,17 +205,19 @@ export async function resetPasswordForEmail(formData: FormData): Promise<AuthRes
   return { success: true };
 } 
 
-// GitHub Sign In
-export async function signInWithGithub(): Promise<GithubAuthResult> {
+// Google Sign In
+export async function signInWithGoogle(): Promise<OAuthAuthResult> {
   const supabase = await createClient();
 
   try {
     const { data, error } = await supabase.auth.signInWithOAuth({
-      provider: 'github',
+      provider: 'google',
       options: {
         redirectTo: `${process.env.NEXT_PUBLIC_SITE_URL}/auth/callback`,
         queryParams: {
-          next: '/'
+          next: '/',
+          access_type: 'offline',
+          prompt: 'consent',
         }
       }
     });

--- a/src/app/auth/login/page.tsx
+++ b/src/app/auth/login/page.tsx
@@ -67,7 +67,10 @@ export default async function LoginPage({
   searchParams: Promise<{ [key: string]: string | undefined }>;
 }) {
   const params = await searchParams;
-  const showErrorDialog = params?.error === 'email_confirmation' || params?.error === 'auth_code_missing';
+  const showErrorDialog =
+    params?.error === 'email_confirmation' ||
+    params?.error === 'auth_code_missing' ||
+    params?.error === 'auth_callback_failed';
 
   return (
     <>

--- a/src/components/analytics/posthog-provider.tsx
+++ b/src/components/analytics/posthog-provider.tsx
@@ -7,6 +7,7 @@ import { sanitizeAnalyticsProperties } from '@/lib/analytics/events';
 
 const posthogKey = process.env.NEXT_PUBLIC_POSTHOG_KEY;
 const posthogHost = process.env.NEXT_PUBLIC_POSTHOG_HOST ?? 'https://us.i.posthog.com';
+const posthogUiHost = process.env.NEXT_PUBLIC_POSTHOG_UI_HOST ?? 'https://us.posthog.com';
 let hasInitialized = false;
 
 interface AnalyticsUser {
@@ -28,6 +29,7 @@ export function PostHogProvider({
 
     posthog.init(posthogKey, {
       api_host: posthogHost,
+      ui_host: posthogUiHost,
       defaults: '2026-01-30',
       capture_pageview: false,
       capture_pageleave: true,

--- a/src/components/auth/auth-dialog-provider.tsx
+++ b/src/components/auth/auth-dialog-provider.tsx
@@ -1,12 +1,10 @@
 'use client';
 
 import { createContext, useCallback, useContext, useMemo, useState } from "react";
-import { toast } from "sonner";
-import { Github, Loader2 } from "lucide-react";
+import { Loader2 } from "lucide-react";
 
-import { signInWithGithub } from "@/app/auth/login/actions";
+import { signInWithGoogle } from "@/app/auth/login/actions";
 import { LoginForm } from "@/components/auth/login-form";
-import { SignupForm } from "@/components/auth/signup-form";
 import { Alert, AlertDescription } from "@/components/ui/alert";
 import { Button } from "@/components/ui/button";
 import { Dialog, DialogContent, DialogDescription, DialogTitle } from "@/components/ui/dialog";
@@ -40,19 +38,19 @@ function TabButton({ value, children }: { value: AuthTab; children: React.ReactN
   );
 }
 
-function SocialAuth() {
+function SocialAuth({ showDivider = true }: { showDivider?: boolean }) {
   const [isLoading, setIsLoading] = useState(false);
   const [errorMessage, setErrorMessage] = useState<string>();
 
-  const handleGithubSignIn = async () => {
+  const handleGoogleSignIn = async () => {
     setErrorMessage(undefined);
 
     try {
       setIsLoading(true);
-      const result = await signInWithGithub();
+      const result = await signInWithGoogle();
 
       if (!result.success) {
-        const message = result.error || "Failed to sign in with GitHub.";
+        const message = result.error || "Failed to sign in with Google.";
         setErrorMessage(message);
         return;
       }
@@ -62,10 +60,10 @@ function SocialAuth() {
         return;
       }
 
-      setErrorMessage("Failed to start GitHub sign in.");
+      setErrorMessage("Failed to start Google sign in.");
     } catch (error) {
-      console.error("Failed to sign in with GitHub:", error);
-      setErrorMessage("Failed to start GitHub sign in.");
+      console.error("Failed to sign in with Google:", error);
+      setErrorMessage("Failed to start Google sign in.");
     } finally {
       setIsLoading(false);
     }
@@ -73,14 +71,16 @@ function SocialAuth() {
 
   return (
     <div className="space-y-3 mt-4">
-      <div className="relative">
-        <div className="absolute inset-0 flex items-center">
-          <Separator className="bg-slate-200" />
+      {showDivider && (
+        <div className="relative">
+          <div className="absolute inset-0 flex items-center">
+            <Separator className="bg-slate-200" />
+          </div>
+          <div className="relative flex justify-center text-xs">
+            <span className="bg-white px-3 text-slate-500">or</span>
+          </div>
         </div>
-        <div className="relative flex justify-center text-xs">
-          <span className="bg-white px-3 text-slate-500">or</span>
-        </div>
-      </div>
+      )}
 
       <Button
         variant="outline"
@@ -90,7 +90,7 @@ function SocialAuth() {
           focus:ring-2 focus:ring-slate-500 focus:ring-offset-1
           rounded-lg
         "
-        onClick={handleGithubSignIn}
+        onClick={handleGoogleSignIn}
         disabled={isLoading}
       >
         {isLoading ? (
@@ -100,8 +100,10 @@ function SocialAuth() {
           </>
         ) : (
           <>
-            <Github className="mr-2 h-4 w-4" />
-            Continue with GitHub
+            <span className="mr-2 inline-flex h-4 w-4 items-center justify-center rounded-full text-sm font-semibold text-slate-700">
+              G
+            </span>
+            Continue with Google
           </>
         )}
       </Button>
@@ -146,11 +148,6 @@ export function AuthDialogProvider({ children }: { children: React.ReactNode }) 
     },
     [closeDialog]
   );
-
-  const handleSignupSuccess = useCallback(() => {
-    toast.success("Account created. Check your email to confirm your account.");
-    closeDialog();
-  }, [closeDialog]);
 
   const contextValue = useMemo(
     () => ({
@@ -199,10 +196,9 @@ export function AuthDialogProvider({ children }: { children: React.ReactNode }) 
                 <TabsContent value="signup" className="mt-0 space-y-4">
                   <div className="text-center mb-4">
                     <h3 className="text-lg font-semibold text-slate-900">Get started</h3>
-                    <p className="text-sm text-slate-600 mt-1">Create your free account</p>
+                    <p className="text-sm text-slate-600 mt-1">Create your free account with Google</p>
                   </div>
-                  <SignupForm key={`signup-${formVersion}`} onSuccess={handleSignupSuccess} />
-                  <SocialAuth />
+                  <SocialAuth showDivider={false} />
                 </TabsContent>
               </div>
             </Tabs>

--- a/src/components/auth/error-dialog.tsx
+++ b/src/components/auth/error-dialog.tsx
@@ -20,16 +20,18 @@ interface ErrorDialogProps {
 export function ErrorDialog({ isOpen: initialIsOpen }: ErrorDialogProps) {
   const [isOpen, setIsOpen] = useState(false);
   const searchParams = useSearchParams();
+  const error = searchParams.get('error');
 
   useEffect(() => {
     setIsOpen(initialIsOpen);
   }, [initialIsOpen]);
 
-  const errorMessage = isOpen ? (
-    searchParams.get('error') === 'auth_code_missing' 
-      ? 'We couldn\'t complete your sign-in. Please try again.' 
+  const isSignInError = error === 'auth_code_missing' || error === 'auth_callback_failed';
+  const errorMessage = isOpen
+    ? isSignInError
+      ? 'We could not complete your sign-in. Please try again.'
       : 'There was an issue with your email confirmation. Please check your inbox and try again.'
-  ) : null;
+    : null;
 
   return (
     <Dialog 
@@ -49,12 +51,24 @@ export function ErrorDialog({ isOpen: initialIsOpen }: ErrorDialogProps) {
         
         <div className="pt-4 space-y-4">
           <p className="text-center text-muted-foreground">
-            There was an error confirming your email address. This could be because:
+            {isSignInError
+              ? 'There was an error completing the authentication flow. This could be because:'
+              : 'There was an error confirming your email address. This could be because:'}
           </p>
           <ul className="list-disc list-inside space-y-2 text-muted-foreground">
-            <li>The confirmation link has expired</li>
-            <li>The link was already used</li>
-            <li>The link is invalid</li>
+            {isSignInError ? (
+              <>
+                <li>The sign-in session expired</li>
+                <li>The browser returned without an authorization code</li>
+                <li>The OAuth provider configuration needs another look</li>
+              </>
+            ) : (
+              <>
+                <li>The confirmation link has expired</li>
+                <li>The link was already used</li>
+                <li>The link is invalid</li>
+              </>
+            )}
           </ul>
           <div className="pt-4 space-y-2">
             <Link href="/">

--- a/src/components/settings/security-form.tsx
+++ b/src/components/settings/security-form.tsx
@@ -21,6 +21,10 @@ export function SecurityForm({ user }: SecurityFormProps) {
   const [emailCurrentPassword, setEmailCurrentPassword] = useState("");
   const [currentPassword, setCurrentPassword] = useState("");
   const [newPassword, setNewPassword] = useState("");
+  const providers = user?.identities?.map((identity) => identity.provider) ?? [];
+  const hasPasswordIdentity = providers.length === 0 || providers.includes("email");
+  const hasGoogleIdentity = providers.includes("google");
+  const isGoogleOnlyUser = hasGoogleIdentity && !hasPasswordIdentity;
 
   const handleEmailUpdate = async () => {
     try {
@@ -74,73 +78,86 @@ export function SecurityForm({ user }: SecurityFormProps) {
     
     <div className="space-y-8">
     {/* <Button onClick={handleTestApiKey}>Test API Key</Button> */}
+
+      {isGoogleOnlyUser && (
+        <div className="rounded-lg border border-teal-200 bg-teal-50/70 p-4 text-sm text-teal-900">
+          <p className="font-medium">Your account uses Google sign-in.</p>
+          <p className="mt-1 text-teal-800">
+            Email and password changes are managed by your Google account, so ResumeLM does not require a separate password here.
+          </p>
+        </div>
+      )}
     
-      {/* Email Change Section */}
-      <div className="space-y-4">
-        <div className="space-y-2">
-          <Label>Email Address</Label>
-          <p className="text-sm text-muted-foreground">Current email: {user?.email}</p>
+      {hasPasswordIdentity && (
+        <>
+          {/* Email Change Section */}
           <div className="space-y-4">
-            <div className="flex gap-4">
-              <Input
-                type="email"
-                placeholder="Enter new email address"
-                value={newEmail}
-                onChange={(e) => setNewEmail(e.target.value)}
-                className="bg-white/50 flex-1"
-              />
-              <Input
-                type="password"
-                placeholder="Current password"
-                value={emailCurrentPassword}
-                onChange={(e) => setEmailCurrentPassword(e.target.value)}
-                className="bg-white/50 flex-1"
-              />
-              <Button 
-                variant="outline"
-                className="bg-white/50 border-teal-200 text-teal-700 hover:bg-teal-50 hover:text-teal-800"
-                onClick={handleEmailUpdate}
-                disabled={isUpdatingEmail || !newEmail || !emailCurrentPassword}
-              >
-                <Loader2 className={`mr-2 h-4 w-4 animate-spin ${!isUpdatingEmail && "opacity-0"}`} />
-                {isUpdatingEmail ? "Updating..." : "Change Email"}
-              </Button>
+            <div className="space-y-2">
+              <Label>Email Address</Label>
+              <p className="text-sm text-muted-foreground">Current email: {user?.email}</p>
+              <div className="space-y-4">
+                <div className="flex gap-4">
+                  <Input
+                    type="email"
+                    placeholder="Enter new email address"
+                    value={newEmail}
+                    onChange={(e) => setNewEmail(e.target.value)}
+                    className="bg-white/50 flex-1"
+                  />
+                  <Input
+                    type="password"
+                    placeholder="Current password"
+                    value={emailCurrentPassword}
+                    onChange={(e) => setEmailCurrentPassword(e.target.value)}
+                    className="bg-white/50 flex-1"
+                  />
+                  <Button 
+                    variant="outline"
+                    className="bg-white/50 border-teal-200 text-teal-700 hover:bg-teal-50 hover:text-teal-800"
+                    onClick={handleEmailUpdate}
+                    disabled={isUpdatingEmail || !newEmail || !emailCurrentPassword}
+                  >
+                    <Loader2 className={`mr-2 h-4 w-4 animate-spin ${!isUpdatingEmail && "opacity-0"}`} />
+                    {isUpdatingEmail ? "Updating..." : "Change Email"}
+                  </Button>
+                </div>
+              </div>
             </div>
           </div>
-        </div>
-      </div>
 
-      {/* Password Reset Section */}
-      <div className="space-y-4">
-        <div className="space-y-2">
-          <Label>Password</Label>
-          <div className="flex gap-4">
-            <Input
-              type="password"
-              placeholder="Enter current password"
-              value={currentPassword}
-              onChange={(e) => setCurrentPassword(e.target.value)}
-              className="bg-white/50"
-            />
-            <Input
-              type="password"
-              placeholder="Enter new password"
-              value={newPassword}
-              onChange={(e) => setNewPassword(e.target.value)}
-              className="bg-white/50"
-            />
-            <Button 
-              variant="outline"
-              className="bg-white/50 border-teal-200 text-teal-700 hover:bg-teal-50 hover:text-teal-800 whitespace-nowrap"
-              onClick={handlePasswordUpdate}
-              disabled={isUpdatingPassword || !currentPassword || !newPassword}
-            >
-              <Loader2 className={`mr-2 h-4 w-4 animate-spin ${!isUpdatingPassword && "opacity-0"}`} />
-              {isUpdatingPassword ? "Updating..." : "Change Password"}
-            </Button>
+          {/* Password Reset Section */}
+          <div className="space-y-4">
+            <div className="space-y-2">
+              <Label>Password</Label>
+              <div className="flex gap-4">
+                <Input
+                  type="password"
+                  placeholder="Enter current password"
+                  value={currentPassword}
+                  onChange={(e) => setCurrentPassword(e.target.value)}
+                  className="bg-white/50"
+                />
+                <Input
+                  type="password"
+                  placeholder="Enter new password"
+                  value={newPassword}
+                  onChange={(e) => setNewPassword(e.target.value)}
+                  className="bg-white/50"
+                />
+                <Button 
+                  variant="outline"
+                  className="bg-white/50 border-teal-200 text-teal-700 hover:bg-teal-50 hover:text-teal-800 whitespace-nowrap"
+                  onClick={handlePasswordUpdate}
+                  disabled={isUpdatingPassword || !currentPassword || !newPassword}
+                >
+                  <Loader2 className={`mr-2 h-4 w-4 animate-spin ${!isUpdatingPassword && "opacity-0"}`} />
+                  {isUpdatingPassword ? "Updating..." : "Change Password"}
+                </Button>
+              </div>
+            </div>
           </div>
-        </div>
-      </div>
+        </>
+      )}
     </div>
   )
 } 

--- a/src/lib/auth-policy.test.ts
+++ b/src/lib/auth-policy.test.ts
@@ -1,0 +1,14 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+
+import { getEmailSignupBlockedMessage, isEmailSignupAllowed } from "./auth-policy";
+
+describe("auth policy", () => {
+  it("requires Google for new account signup", () => {
+    assert.equal(isEmailSignupAllowed(), false);
+    assert.equal(
+      getEmailSignupBlockedMessage(),
+      "New accounts must be created with Google. Existing users can still sign in with email and password."
+    );
+  });
+});

--- a/src/lib/auth-policy.ts
+++ b/src/lib/auth-policy.ts
@@ -1,0 +1,10 @@
+export const EMAIL_SIGNUP_BLOCKED_MESSAGE =
+  "New accounts must be created with Google. Existing users can still sign in with email and password.";
+
+export function isEmailSignupAllowed() {
+  return false;
+}
+
+export function getEmailSignupBlockedMessage() {
+  return EMAIL_SIGNUP_BLOCKED_MESSAGE;
+}


### PR DESCRIPTION
## Summary
- replace the auth dialog OAuth path with Google
- make new account creation Google-only while keeping email/password login for existing users
- add callback error handling and provider-aware security settings

## Validation
- pnpm test
- pnpm typecheck
- local callback smoke check for missing auth code redirect

## Notes
- Google/Supabase provider configuration must be complete in the dashboard before production rollout.
- Existing password users remain supported; forced account linking is intentionally out of scope.