### PR TITLE
Route free chat assistant to gpt-5.4-nano and update tests

### DIFF
--- a/src/lib/ai-models.ts
+++ b/src/lib/ai-models.ts
@@ -400,7 +400,7 @@ export const MODEL_DESIGNATIONS = {
   JOB_TAILORING_FREE: 'gpt-5.4-nano',
   JOB_TAILORING_PRO: 'gpt-5.5',
   // Interactive assistant by plan
-  CHAT_ASSISTANT_FREE: 'gpt-5.4-mini',
+  CHAT_ASSISTANT_FREE: 'gpt-5.4-nano',
   CHAT_ASSISTANT_PRO: 'gpt-5.5',
   // Frontier model for complex tasks, deep analysis, best quality
   FRONTIER: 'gpt-5.5',

--- a/src/lib/ai/task-models.test.ts
+++ b/src/lib/ai/task-models.test.ts
@@ -24,6 +24,11 @@ describe("task model routing", () => {
     assert.equal(getTaskModel("coverLetter", true), "gpt-5.4-mini");
   });
 
+  it("routes free chat assistant to GPT-5.4 Nano", () => {
+    assert.equal(getTaskModel("chatAssistant", false), "gpt-5.4-nano");
+    assert.equal(getTaskModel("chatAssistant", true), "gpt-5.5");
+  });
+
   it("preserves API keys and custom prompts while replacing the model", () => {
     const config: AIConfig = {
       model: "claude-sonnet-4-6",


### PR DESCRIPTION
### Motivation
- Route the free chat assistant to `gpt-5.4-nano` to align it with other fast/cheap designations and reduce cost and latency.

### Description
- Change `MODEL_DESIGNATIONS.CHAT_ASSISTANT_FREE` from `gpt-5.4-mini` to `gpt-5.4-nano` and add a unit test in `src/lib/ai/task-models.test.ts` asserting `chatAssistant` routing for free and pro users.

### Testing
- Ran `npm test` and the test suite including `task-models.test.ts` (which contains the new chat assistant routing test) passed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a03738d175483219f043e3c80066e2f)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/olyaiy/resume-lm/pull/56" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->