### PR TITLE
fix(cover-letter): render PDF via @react-pdf instead of html2canvas

### DIFF
--- a/src/components/cover-letter/cover-letter-pdf-document.tsx
+++ b/src/components/cover-letter/cover-letter-pdf-document.tsx
@@ -1,0 +1,135 @@
+'use client';
+
+import {
+  Document as PDFDocument,
+  Page as PDFPage,
+  Text,
+  View,
+  StyleSheet,
+} from '@react-pdf/renderer';
+import type { ReactNode } from 'react';
+
+// Renders the cover letter through @react-pdf (the same engine the resume PDF
+// uses) instead of rasterizing the DOM with html2canvas. html2canvas clones the
+// whole document to render and bails out to a blank page when the page contains
+// a tainted <canvas> (pdf.js / the resume preview), which is unavoidable here.
+// @react-pdf builds the PDF directly from the markup and never touches the DOM.
+
+const styles = StyleSheet.create({
+  page: {
+    paddingVertical: 56,
+    paddingHorizontal: 56,
+    fontFamily: 'Helvetica',
+    fontSize: 11,
+    lineHeight: 1.5,
+    color: '#1a1a1a',
+  },
+  block: { marginBottom: 10 },
+  h1: { fontSize: 18, fontWeight: 'bold', marginBottom: 10 },
+  h2: { fontSize: 15, fontWeight: 'bold', marginBottom: 8 },
+  h3: { fontSize: 13, fontWeight: 'bold', marginBottom: 6 },
+});
+
+const TEXT_NODE = 3;
+const ELEMENT_NODE = 1;
+
+// Inline formatting: nested <Text> with bold/italic/underline.
+function inlineStyleFor(tag: string) {
+  switch (tag) {
+    case 'STRONG':
+    case 'B':
+      return { fontWeight: 'bold' as const };
+    case 'EM':
+    case 'I':
+      return { fontStyle: 'italic' as const };
+    case 'U':
+    case 'INS':
+      return { textDecoration: 'underline' as const };
+    case 'S':
+    case 'STRIKE':
+    case 'DEL':
+      return { textDecoration: 'line-through' as const };
+    default:
+      return {};
+  }
+}
+
+function renderInline(node: Node, key: string): ReactNode[] {
+  const out: ReactNode[] = [];
+  node.childNodes.forEach((child, i) => {
+    const k = `${key}-${i}`;
+    if (child.nodeType === TEXT_NODE) {
+      const text = child.textContent ?? '';
+      if (text) out.push(text);
+    } else if (child.nodeType === ELEMENT_NODE) {
+      const el = child as Element;
+      if (el.tagName === 'BR') {
+        out.push(<Text key={k}>{'\n'}</Text>);
+      } else {
+        out.push(
+          <Text key={k} style={inlineStyleFor(el.tagName)}>
+            {renderInline(el, k)}
+          </Text>,
+        );
+      }
+    }
+  });
+  return out;
+}
+
+const BLOCK_CONTAINERS = new Set(['DIV', 'UL', 'OL', 'BLOCKQUOTE']);
+
+// Flatten block-level markup into a list of react-pdf paragraphs. Containers
+// (the prose wrapper div, lists) are descended into; everything else is treated
+// as a paragraph.
+function renderBlocks(parent: Node, keyBase: string): ReactNode[] {
+  const blocks: ReactNode[] = [];
+  parent.childNodes.forEach((child, i) => {
+    if (child.nodeType !== ELEMENT_NODE) return;
+    const el = child as Element;
+    const tag = el.tagName;
+    const k = `${keyBase}-${i}`;
+
+    if (BLOCK_CONTAINERS.has(tag)) {
+      blocks.push(...renderBlocks(el, k));
+      return;
+    }
+
+    const blockStyle =
+      tag === 'H1' ? styles.h1
+      : tag === 'H2' ? styles.h2
+      : tag === 'H3' || tag === 'H4' || tag === 'H5' || tag === 'H6' ? styles.h3
+      : styles.block;
+
+    const align = (el as HTMLElement).style?.textAlign;
+    const style = align
+      ? [blockStyle, { textAlign: align as 'left' | 'center' | 'right' | 'justify' }]
+      : blockStyle;
+
+    const prefix = tag === 'LI' ? '•  ' : '';
+    blocks.push(
+      <Text key={k} style={style}>
+        {prefix}
+        {renderInline(el, k)}
+      </Text>,
+    );
+  });
+  return blocks;
+}
+
+export function CoverLetterPDFDocument({ html }: { html: string }) {
+  const parsed = new DOMParser().parseFromString(html || '', 'text/html');
+  const blocks = renderBlocks(parsed.body, 'cl');
+
+  return (
+    <PDFDocument>
+      <PDFPage size="LETTER" style={styles.page}>
+        <View>
+          {blocks.length > 0
+            ? blocks
+            : <Text>{parsed.body.textContent ?? ''}</Text>}
+        </View>
+      </PDFPage>
+    </PDFDocument>
+  );
+}

--- a/src/components/resume/editor/actions/resume-editor-actions.tsx
+++ b/src/components/resume/editor/actions/resume-editor-actions.tsx
@@ -7,6 +7,7 @@ import { toast } from "@/hooks/use-toast";
 import { pdf } from '@react-pdf/renderer';
 import { TextImport } from "../../text-import";
 import { ResumePDFDocument } from "../preview/resume-pdf-document";
+import { CoverLetterPDFDocument } from "@/components/cover-letter/cover-letter-pdf-document";
 import { cn } from "@/lib/utils";
 import { useResumeContext } from "../resume-editor-context";
 
@@ -128,36 +129,26 @@ export function ResumeEditorActions({
 
                     // Download Cover Letter if selected and exists
                     if (downloadOptions.coverLetter && resume.has_cover_letter) {
-                      // Dynamically import html2pdf only when needed
-                      const html2pdf = (await import('html2pdf.js')).default;
-                      
+                      // Read the rendered HTML from the off-screen print element
+                      // (always reflects the current cover letter), then build the
+                      // PDF with @react-pdf — same engine as the resume, immune to
+                      // the html2canvas tainted-canvas failure on this page.
                       const coverLetterElement = document.getElementById('cover-letter-content');
-                      if (!coverLetterElement) {
-                        throw new Error('Cover letter content not found');
-                      }
+                      const coverLetterHtml =
+                        (coverLetterElement?.firstElementChild as HTMLElement | null)?.innerHTML
+                        ?? coverLetterElement?.innerHTML
+                        ?? (resume.cover_letter?.content as string | undefined)
+                        ?? '';
 
-                      const opt = {
-                        margin: [0, 0, -0.5, 0],
-                        filename: `${resume.first_name}_${resume.last_name}_Cover_Letter.pdf`,
-                        image: { type: 'jpeg', quality: 0.98 },
-                        html2canvas: {
-                          backgroundColor: 'red',
-                          useCORS: true,
-                          letterRendering: true,
-                          // width: 700,
-                          // height: 1000,
-                          // windowWidth: 700,
-                          logging: true,
-                          // windowHeight: 2000
-                        },
-                        jsPDF: { 
-                          unit: 'in', 
-                          format: 'letter', 
-                          orientation: 'portrait' 
-                        }
-                      };
-
-                      await html2pdf().set(opt).from(coverLetterElement).save();
+                      const blob = await pdf(<CoverLetterPDFDocument html={coverLetterHtml} />).toBlob();
+                      const url = URL.createObjectURL(blob);
+                      const link = document.createElement('a');
+                      link.href = url;
+                      link.download = `${resume.first_name}_${resume.last_name}_Cover_Letter.pdf`;
+                      document.body.appendChild(link);
+                      link.click();
+                      document.body.removeChild(link);
+                      URL.revokeObjectURL(url);
                     }
 
                     toast({


### PR DESCRIPTION
## Problem
Downloading a cover letter as a PDF produces a blank page.

## Root cause
The download rasterizes an off-screen DOM element with html2canvas (via `html2pdf.js`). html2canvas clones the entire document to render, and **aborts to a blank result when the page contains a tainted `<canvas>`** — which it always does on the resume editor, because pdf.js and the resume preview draw cross-origin content. (The config also carried debug leftovers: a red background, `logging: true`, and a negative margin.)

This is why the resume PDF works but the cover letter doesn't: the resume already renders through `@react-pdf`, which never touches the DOM or a canvas.

## Fix
Render the cover letter through `@react-pdf/renderer` (already a dependency) instead of html2canvas. A new `CoverLetterPDFDocument` parses the cover letter HTML — paragraphs, line breaks, and bold/italic/underline — into PDF primitives and builds the file directly. No DOM rasterization, no canvas, so the tainted-canvas failure cannot occur.

## Testing
Manually verified: the downloaded PDF now contains the full cover letter text (previously blank). Resume download is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
