### PR TITLE
fix(resume-score): harden scoring schema and structured-output limits

### DIFF
--- a/src/lib/zod-schemas.ts
+++ b/src/lib/zod-schemas.ts
@@ -321,11 +321,14 @@ export const resumeScoreSchema = z.object({
       suggestions: z.array(z.string()).optional()
     })
   }).optional(),
+  // One predictable shape (matching the documented prompt format and the
+  // resume-score-panel consumer type) instead of a number|object union, which
+  // small models satisfy inconsistently and trips schema validation.
   miscellaneous: z.record(
-    z.union([z.number(), z.object({
-      score: z.number().min(0).max(100).optional(),
-      reason: z.string().optional()
-    })]).optional()
+    z.object({
+      score: z.number().min(0).max(100),
+      reason: z.string()
+    })
   ).optional(),
   overallImprovements: z.array(z.string()).optional(),
   // Job-specific improvements for tailored resumes

--- a/src/utils/actions/resumes/actions.ts
+++ b/src/utils/actions/resumes/actions.ts
@@ -6,7 +6,7 @@ import { revalidatePath } from 'next/cache';
 import { z } from 'zod';
 import { simplifiedResumeSchema, Job as ZodJob } from "@/lib/zod-schemas";
 import { AIConfig } from "@/utils/ai-tools";
-import { generateObject, type LanguageModelUsage, type LanguageModelV1, type TelemetrySettings } from "ai";
+import { generateObject, NoObjectGeneratedError, type LanguageModelUsage, type LanguageModelV1, type TelemetrySettings } from "ai";
 import { resumeScoreSchema } from "@/lib/zod-schemas";
 import { getSubscriptionPlan } from "../stripe/actions";
 import { getSubscriptionAccessState } from "@/lib/subscription-access";
@@ -625,13 +625,27 @@ export async function generateResumeScore(
       model: aiClient,
       experimental_telemetry: telemetry,
       schema: resumeScoreSchema,
+      // The scoring schema is large; the default 4096-token cap truncates the
+      // JSON for verbose (tailored) resumes, producing NoObjectGeneratedError.
+      maxTokens: 8192,
       prompt
     }));
 
     // console.log("THE OUTPUTTED object", object);
     return object
   } catch (error) {
-    console.error('Error SCORING resume:', error);
+    if (NoObjectGeneratedError.isInstance(error)) {
+      // Surface what the model actually produced so schema-mismatch vs.
+      // truncation is diagnosable instead of an opaque overlay error.
+      console.error('Error SCORING resume: model output did not match resumeScoreSchema', {
+        finishReason: error.finishReason,
+        usage: error.usage,
+        cause: error.cause,
+        text: error.text,
+      });
+    } else {
+      console.error('Error SCORING resume:', error);
+    }
     throw error;
   }
 }


### PR DESCRIPTION
## Problem
`generateResumeScore` intermittently fails with a 500, especially on tailored resumes.

## Causes (both provider-agnostic)
1. **Fragile schema.** The `miscellaneous` field accepts a `number | object` union with all-optional inner fields. Models satisfy this inconsistently, which trips Zod validation. This PR uses one predictable `{ score, reason }` shape, matching the documented prompt format and the score-panel consumer type.
2. **Truncation.** `generateObject` runs at the default 4096-token cap, which truncates the large scoring JSON for verbose (tailored) resumes and yields `NoObjectGeneratedError`. This PR raises `maxTokens` to 8192, and on `NoObjectGeneratedError` logs the model's actual output so a schema mismatch vs. a truncation is diagnosable instead of surfacing as an opaque error.

## Note (why draft)
These are real, model-independent robustness fixes, but I validated them against Anthropic models rather than the default `gpt-5.4-nano` this repo ships for scoring. Opened as a draft for maintainer review/validation on the default model before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
