### PR TITLE
Route AI defaults through OpenRouter and honor selected models

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,11 +4,14 @@
 NEXT_PUBLIC_SITE_URL=http://localhost:3000
 
 # ===========================================
-# AI PROVIDERS (Add at least one)
+# AI PROVIDERS
 # ===========================================
-OPENAI_API_KEY=
-ANTHROPIC_API_KEY=
+# Required for ResumeLM's app-funded defaults (GPT-5.6 Luna and GPT-5.5)
 OPENROUTER_API_KEY=
+# Optional bring-your-own-key provider
+ANTHROPIC_API_KEY=
+# Retained for compatibility with custom/legacy deployments
+OPENAI_API_KEY=
 
 # ===========================================
 # SUPABASE (Pre-configured for Docker)

--- a/README.md
+++ b/README.md
@@ -149,7 +149,7 @@ SUPABASE_URL=your_supabase_url
 SUPABASE_ANON_KEY=your_supabase_anon_key
 
 # AI Services
-OPENAI_API_KEY=your_openai_key
+OPENROUTER_API_KEY=your_openrouter_key
 ANTHROPIC_API_KEY=your_claude_key
 GOOGLE_AI_API_KEY=your_gemini_key
 
@@ -183,7 +183,7 @@ Run the complete stack locally with Docker Compose - includes Supabase, PostgreS
 ```bash
 # 1. Copy environment file and add your AI API key
 cp .env.example .env.local
-# Edit .env.local and add at least one: OPENAI_API_KEY, ANTHROPIC_API_KEY, or OPENROUTER_API_KEY
+# Edit .env.local and add OPENROUTER_API_KEY for ResumeLM's default models
 
 # 2. Start Docker services
 cd docker

--- a/docker/DOCKER.md
+++ b/docker/DOCKER.md
@@ -7,7 +7,7 @@ Run the complete ResumeLM stack locally using Docker Compose.
 ```bash
 # 1. Copy environment file and add your AI API key
 cp .env.example .env.local
-# Edit .env.local and add at least one: OPENAI_API_KEY, ANTHROPIC_API_KEY, or OPENROUTER_API_KEY
+# Edit .env.local and add OPENROUTER_API_KEY for ResumeLM's default models
 
 # 2. Start Docker services
 cd docker

--- a/src/app/api/chat/route.ts
+++ b/src/app/api/chat/route.ts
@@ -47,17 +47,6 @@ export async function POST(req: Request) {
       isPro,
     });
 
-    // Some models (e.g., GPT-5 family / GPT-5 Mini) only support the default temperature (1)
-    const requiresDefaultTemp = [
-      'gpt-5',
-      'gpt-5.4',
-      'gpt-5.4-mini',
-      'gpt-5.4-nano',
-      'gpt-5.4-pro',
-      'gpt-5.5',
-      'gpt-5.5-pro',
-    ].includes(routedConfig.model);
-    
     // Gemini models support a thinking phase—explicitly disable it to avoid added latency/cost
     // For OpenRouter models, use the unified 'reasoning' parameter via providerOptions.openrouter
     const isGeminiModel = routedConfig.model.toLowerCase().includes('gemini-3');
@@ -147,7 +136,6 @@ export async function POST(req: Request) {
     // Build and send the AI call.
     const result = streamText({
       model: aiClient as LanguageModelV1,
-      ...(requiresDefaultTemp ? { temperature: 1 } : {}),
       ...(providerOptions ? { providerOptions } : {}),
       system: systemPrompt,
       messages,

--- a/src/components/profile/profile-edit-form.tsx
+++ b/src/components/profile/profile-edit-form.tsx
@@ -33,6 +33,7 @@ import { AlertDialog, AlertDialogAction, AlertDialogCancel, AlertDialogContent, 
 import { ProUpgradeButton } from "@/components/settings/pro-upgrade-button";
 import { AlertTriangle } from "lucide-react";
 import { importResume, updateProfile } from "@/utils/actions/profiles/actions";
+import { getCanonicalModelId, MODEL_DESIGNATIONS } from "@/lib/ai-models";
 import { cn, withBasePath } from "@/lib/utils";
 import pdfToText from "react-pdftotext";
 
@@ -151,7 +152,9 @@ export function ProfileEditForm({ profile: initialProfile }: ProfileEditFormProp
       const MODEL_STORAGE_KEY = 'resumelm-default-model';
       const LOCAL_STORAGE_KEY = 'resumelm-api-keys';
       
-      const selectedModel = localStorage.getItem(MODEL_STORAGE_KEY) || 'gpt-5.4-nano';
+      const selectedModel = getCanonicalModelId(
+        localStorage.getItem(MODEL_STORAGE_KEY) || MODEL_DESIGNATIONS.DEFAULT_FREE
+      );
       const storedKeys = localStorage.getItem(LOCAL_STORAGE_KEY);
       let apiKeys = [];
       

--- a/src/components/settings/api-keys-form.tsx
+++ b/src/components/settings/api-keys-form.tsx
@@ -144,7 +144,7 @@ export function ApiKeysForm({ isProPlan }: { isProPlan: boolean }) {
           Default AI Model
         </Label>
         <p className="text-sm text-muted-foreground mt-2 mb-3">
-          This model will be used for all AI operations throughout the application. All models require their respective API keys.
+          This model will be used for all AI operations throughout the application. App-funded models work without a personal API key.
         </p>
         <ModelSelector
           value={defaultModel}

--- a/src/hooks/use-api-keys.ts
+++ b/src/hooks/use-api-keys.ts
@@ -1,7 +1,7 @@
 'use client'
 
 import { useSyncExternalStore, useCallback } from 'react'
-import type { ApiKey } from '@/lib/ai-models'
+import { getCanonicalModelId, type ApiKey } from '@/lib/ai-models'
 
 // Storage keys - must match existing keys for backwards compatibility
 const API_KEYS_STORAGE_KEY = 'resumelm-api-keys'
@@ -57,7 +57,7 @@ function handleStorageChange(event: StorageEvent) {
   }
 
   if (event.key === MODEL_STORAGE_KEY) {
-    const nextModel = event.newValue ?? EMPTY_MODEL
+    const nextModel = normalizeModelId(event.newValue ?? EMPTY_MODEL)
     if (nextModel !== currentDefaultModel) {
       currentDefaultModel = nextModel
       emitModelChange()
@@ -73,7 +73,18 @@ function readStoredApiKeys(): ApiKey[] {
 
 function readStoredModel(): string {
   if (typeof window === 'undefined') return EMPTY_MODEL
-  return localStorage.getItem(MODEL_STORAGE_KEY) ?? EMPTY_MODEL
+  const storedModel = localStorage.getItem(MODEL_STORAGE_KEY) ?? EMPTY_MODEL
+  const normalizedModel = normalizeModelId(storedModel)
+
+  if (normalizedModel !== storedModel) {
+    localStorage.setItem(MODEL_STORAGE_KEY, normalizedModel)
+  }
+
+  return normalizedModel
+}
+
+function normalizeModelId(modelId: string): string {
+  return modelId ? getCanonicalModelId(modelId) : EMPTY_MODEL
 }
 
 function parseApiKeys(raw: string | null): ApiKey[] {
@@ -226,7 +237,7 @@ export function useDefaultModel() {
   const setDefaultModel = useCallback((model: string) => {
     ensureClientStoresInitialized()
 
-    const nextModel = model ?? EMPTY_MODEL
+    const nextModel = normalizeModelId(model ?? EMPTY_MODEL)
     if (nextModel === currentDefaultModel) {
       return
     }

--- a/src/lib/ai-models.test.ts
+++ b/src/lib/ai-models.test.ts
@@ -1,0 +1,47 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+
+import {
+  getCanonicalModelId,
+  getDefaultModel,
+  getModelById,
+  getModelSDKConfig,
+  getProvidersArray,
+} from "@/lib/ai-models";
+
+describe("AI model configuration", () => {
+  it("uses OpenRouter models for both app-funded defaults", () => {
+    assert.equal(getDefaultModel(false), "openai/gpt-5.6-luna");
+    assert.equal(getDefaultModel(true), "openai/gpt-5.5");
+
+    assert.equal(getModelSDKConfig(getDefaultModel(false))?.provider.id, "openrouter");
+    assert.equal(getModelSDKConfig(getDefaultModel(true))?.provider.id, "openrouter");
+  });
+
+  it("configures GPT-5.6 Luna as the app-funded low-cost model", () => {
+    const luna = getModelById("openai/gpt-5.6-luna");
+
+    assert.ok(luna);
+    assert.equal(luna.provider, "openrouter");
+    assert.equal(luna.features.isFree, true);
+    assert.equal(luna.features.supportsVision, true);
+    assert.equal(luna.features.supportsTools, true);
+    assert.equal(luna.features.maxTokens, 1_050_000);
+    assert.equal(luna.availability.requiresApiKey, false);
+  });
+
+  it("migrates legacy direct OpenAI defaults to canonical OpenRouter IDs", () => {
+    assert.equal(getCanonicalModelId("gpt-5.4-nano"), "openai/gpt-5.6-luna");
+    assert.equal(getModelById("gpt-5.4-nano")?.id, "openai/gpt-5.6-luna");
+    assert.deepEqual(getModelSDKConfig("gpt-5.4-nano"), {
+      provider: getModelSDKConfig("openai/gpt-5.6-luna")?.provider,
+      modelId: "openai/gpt-5.6-luna",
+    });
+  });
+
+  it("only shows providers that have selectable models", () => {
+    const providerIds = getProvidersArray().map(provider => provider.id);
+
+    assert.deepEqual(providerIds, ["anthropic", "openrouter"]);
+  });
+});

--- a/src/lib/ai-models.ts
+++ b/src/lib/ai-models.ts
@@ -96,11 +96,13 @@ export const PROVIDERS: Partial<Record<ServiceName, AIProvider>> = {
 // ========================
 
 export const AI_MODELS: AIModel[] = [
-  // OpenAI Models
+  // OpenAI models served through OpenRouter. Keeping app-funded models on one
+  // provider gives us a single billing surface and avoids direct OpenAI key
+  // exhaustion taking down the product.
   {
-    id: 'gpt-5.5',
+    id: 'openai/gpt-5.5',
     name: 'GPT-5.5',
-    provider: 'openai',
+    provider: 'openrouter',
     features: {
       isRecommended: true,
       isUnstable: false,
@@ -110,14 +112,14 @@ export const AI_MODELS: AIModel[] = [
       isPro: true
     },
     availability: {
-      requiresApiKey: true,
+      requiresApiKey: false,
       requiresPro: true
     }
   },
   {
-    id: 'gpt-5.5-pro',
+    id: 'openai/gpt-5.5-pro',
     name: 'GPT-5.5 Pro',
-    provider: 'openai',
+    provider: 'openrouter',
     features: {
       isRecommended: false,
       isUnstable: false,
@@ -127,69 +129,20 @@ export const AI_MODELS: AIModel[] = [
       isPro: true
     },
     availability: {
-      requiresApiKey: true,
+      requiresApiKey: false,
       requiresPro: true
     }
   },
   {
-    id: 'gpt-5.4',
-    name: 'GPT-5.4',
-    provider: 'openai',
+    id: 'openai/gpt-5.6-luna',
+    name: 'GPT-5.6 Luna',
+    provider: 'openrouter',
     features: {
-      isRecommended: false,
-      isUnstable: false,
-      maxTokens: 1050000,
-      supportsVision: true,
-      supportsTools: true,
-      isPro: true
-    },
-    availability: {
-      requiresApiKey: true,
-      requiresPro: true
-    }
-  },
-  {
-    id: 'gpt-5.4-pro',
-    name: 'GPT-5.4 Pro',
-    provider: 'openai',
-    features: {
-      isRecommended: false,
-      isUnstable: false,
-      maxTokens: 1050000,
-      supportsVision: true,
-      supportsTools: true,
-      isPro: true
-    },
-    availability: {
-      requiresApiKey: true,
-      requiresPro: true
-    }
-  },
-  {
-    id: 'gpt-5.4-mini',
-    name: 'GPT-5.4 Mini',
-    provider: 'openai',
-    features: {
-      isRecommended: false,
-      isUnstable: false,
-      maxTokens: 400000,
-      supportsVision: true,
-      supportsTools: true
-    },
-    availability: {
-      requiresApiKey: true,
-      requiresPro: false
-    }
-  },
-  {
-    id: 'gpt-5.4-nano',
-    name: 'GPT-5.4 Nano',
-    provider: 'openai',
-    features: {
+      // "Free" means app-funded for ResumeLM users, not zero provider cost.
       isFree: true,
       isRecommended: true,
       isUnstable: false,
-      maxTokens: 400000,
+      maxTokens: 1050000,
       supportsVision: true,
       supportsTools: true
     },
@@ -348,16 +301,24 @@ const MODEL_ALIASES: Record<string, string> = {
   'claude-sonnet-4-5-20250929': 'claude-sonnet-4-6',
   'claude-opus-4.5': 'claude-opus-4-7',
   'claude-opus-4-5-20251101': 'claude-opus-4-7',
-  // Older GPT IDs → current app defaults/equivalents
-  'gpt-5': 'gpt-5.5',
-  'gpt-5.2': 'gpt-5.5',
-  'gpt-5.2-2025-12-11': 'gpt-5.5',
-  'gpt-5.2-pro': 'gpt-5.5-pro',
-  'gpt-5.2-pro-2025-12-11': 'gpt-5.5-pro',
-  'gpt-5.1-chat': 'gpt-5.4-mini',
-  'gpt-5-mini-2025-08-07': 'gpt-5.4-mini',
-  'gpt-5-mini': 'gpt-5.4-mini',
-  'gpt-5-nano': 'gpt-5.4-nano',
+  // Direct OpenAI and older GPT IDs → OpenRouter-managed equivalents.
+  // This also migrates existing localStorage selections away from the
+  // exhausted direct OpenAI server key.
+  'gpt-5': 'openai/gpt-5.5',
+  'gpt-5.2': 'openai/gpt-5.5',
+  'gpt-5.2-2025-12-11': 'openai/gpt-5.5',
+  'gpt-5.2-pro': 'openai/gpt-5.5-pro',
+  'gpt-5.2-pro-2025-12-11': 'openai/gpt-5.5-pro',
+  'gpt-5.4': 'openai/gpt-5.5',
+  'gpt-5.4-pro': 'openai/gpt-5.5-pro',
+  'gpt-5.5': 'openai/gpt-5.5',
+  'gpt-5.5-pro': 'openai/gpt-5.5-pro',
+  'gpt-5.1-chat': 'openai/gpt-5.6-luna',
+  'gpt-5.4-mini': 'openai/gpt-5.6-luna',
+  'gpt-5.4-nano': 'openai/gpt-5.6-luna',
+  'gpt-5-mini-2025-08-07': 'openai/gpt-5.6-luna',
+  'gpt-5-mini': 'openai/gpt-5.6-luna',
+  'gpt-5-nano': 'openai/gpt-5.6-luna',
   // Allow DeepSeek without the nitro suffix
   'deepseek/deepseek-v3.2': 'deepseek/deepseek-v3.2:nitro',
   // Legacy Gemini 3 model ID without provider prefix
@@ -369,8 +330,8 @@ const MODEL_ALIASES: Record<string, string> = {
 // ========================
 
 export const DEFAULT_MODELS = {
-  PRO_USER: 'gpt-5.5',
-  FREE_USER: 'gpt-5.4-nano'
+  PRO_USER: 'openai/gpt-5.5',
+  FREE_USER: 'openai/gpt-5.6-luna'
 } as const
 
 // ========================
@@ -383,40 +344,44 @@ export const DEFAULT_MODELS = {
  */
 export const MODEL_DESIGNATIONS = {
   // Fast & cheap model for parsing, simple tasks, quick analysis
-  FAST_CHEAP: 'gpt-5.4-nano',
+  FAST_CHEAP: 'openai/gpt-5.6-luna',
   // Alternative fast & cheap option (free for all users)
-  FAST_CHEAP_FREE: 'gpt-5.4-nano',
+  FAST_CHEAP_FREE: 'openai/gpt-5.6-luna',
   // Structured extraction, parsing, and data normalization
-  STRUCTURED_EXTRACTION: 'gpt-5.4-nano',
+  STRUCTURED_EXTRACTION: 'openai/gpt-5.6-luna',
   // Resume scoring and analysis
-  RESUME_SCORING: 'gpt-5.4-nano',
+  RESUME_SCORING: 'openai/gpt-5.6-luna',
   // Single-item rewrites and lightweight editing
-  SIMPLE_REWRITE: 'gpt-5.4-nano',
+  SIMPLE_REWRITE: 'openai/gpt-5.6-luna',
   // Multi-bullet and polished content generation
-  CONTENT_GENERATION: 'gpt-5.4-mini',
+  CONTENT_GENERATION: 'openai/gpt-5.6-luna',
   // Cover letter generation
-  COVER_LETTER: 'gpt-5.4-mini',
+  COVER_LETTER: 'openai/gpt-5.6-luna',
   // Full resume tailoring by plan
-  JOB_TAILORING_FREE: 'gpt-5.4-nano',
-  JOB_TAILORING_PRO: 'gpt-5.5',
+  JOB_TAILORING_FREE: 'openai/gpt-5.6-luna',
+  JOB_TAILORING_PRO: 'openai/gpt-5.5',
   // Interactive assistant by plan
-  CHAT_ASSISTANT_FREE: 'gpt-5.4-nano',
-  CHAT_ASSISTANT_PRO: 'gpt-5.5',
+  CHAT_ASSISTANT_FREE: 'openai/gpt-5.6-luna',
+  CHAT_ASSISTANT_PRO: 'openai/gpt-5.5',
   // Frontier model for complex tasks, deep analysis, best quality
-  FRONTIER: 'gpt-5.5',
+  FRONTIER: 'openai/gpt-5.5',
   // Alternative frontier model
   FRONTIER_ALT: 'claude-opus-4-7',
   // Balanced model - good quality but faster/cheaper than frontier
-  BALANCED: 'gpt-5.4-mini',
+  BALANCED: 'openai/gpt-5.6-luna',
   // Vision-capable model for image analysis
-  VISION: 'gpt-5.4-mini',
+  VISION: 'openai/gpt-5.6-luna',
   // Default models by user type
-  DEFAULT_PRO: 'gpt-5.5',
-  DEFAULT_FREE: 'gpt-5.4-nano'
+  DEFAULT_PRO: 'openai/gpt-5.5',
+  DEFAULT_FREE: 'openai/gpt-5.6-luna'
 } as const
 
 // Type for model designations
 export type ModelDesignation = keyof typeof MODEL_DESIGNATIONS
+
+export function getCanonicalModelId(modelId: string): string {
+  return MODEL_ALIASES[modelId] || modelId
+}
 
 // ========================
 // Utility Functions
@@ -426,14 +391,15 @@ export type ModelDesignation = keyof typeof MODEL_DESIGNATIONS
  * Get all providers as an array
  */
 export function getProvidersArray(): AIProvider[] {
-  return Object.values(PROVIDERS)
+  const selectableProviders = new Set(AI_MODELS.map(model => model.provider))
+  return Object.values(PROVIDERS).filter(provider => selectableProviders.has(provider.id))
 }
 
 /**
  * Get a model by its ID
  */
 export function getModelById(id: string): AIModel | undefined {
-  const resolvedId = MODEL_ALIASES[id] || id
+  const resolvedId = getCanonicalModelId(id)
   return AI_MODELS.find(model => model.id === resolvedId)
 }
 
@@ -459,7 +425,7 @@ export function isModelAvailable(
   isPro: boolean,
   apiKeys: ApiKey[]
 ): boolean {
-  modelId = MODEL_ALIASES[modelId] || modelId
+  modelId = getCanonicalModelId(modelId)
   // Pro users have access to all models
   if (isPro) return true
 
@@ -535,11 +501,12 @@ export function getSelectableModels(isPro: boolean, apiKeys: ApiKey[]): AIModel[
  * Determine which SDK to use for a model
  */
 export function getModelSDKConfig(modelId: string): { provider: AIProvider; modelId: string } | undefined {
-  const model = getModelById(modelId)
+  const canonicalModelId = getCanonicalModelId(modelId)
+  const model = getModelById(canonicalModelId)
   if (!model) return undefined
   
   const provider = getProviderById(model.provider)
   if (!provider) return undefined
   
-  return { provider, modelId }
+  return { provider, modelId: canonicalModelId }
 }

--- a/src/lib/ai/access-control.test.ts
+++ b/src/lib/ai/access-control.test.ts
@@ -17,17 +17,17 @@ afterEach(() => {
 
 describe("resolveAIRequest", () => {
   it("allows free users to use explicitly free server-key models", () => {
-    process.env.OPENAI_API_KEY = "server-openai";
+    process.env.OPENROUTER_API_KEY = "server-openrouter";
 
     const result = resolveAIRequest({
-      requestedModel: "gpt-5.4-nano",
+      requestedModel: "openai/gpt-5.6-luna",
       apiKeys: [],
       isPro: false,
     });
 
-    assert.equal(result.providerId, "openai");
-    assert.equal(result.modelId, "gpt-5.4-nano");
-    assert.equal(result.apiKey, "server-openai");
+    assert.equal(result.providerId, "openrouter");
+    assert.equal(result.modelId, "openai/gpt-5.6-luna");
+    assert.equal(result.apiKey, "server-openrouter");
     assert.equal(result.usedServerKey, true);
     assert.equal(result.requiresRateLimit, true);
   });
@@ -47,17 +47,17 @@ describe("resolveAIRequest", () => {
   });
 
   it("allows Pro users to use configured server-key Pro models", () => {
-    process.env.OPENAI_API_KEY = "server-openai";
+    process.env.OPENROUTER_API_KEY = "server-openrouter";
 
     const result = resolveAIRequest({
-      requestedModel: "gpt-5.5",
+      requestedModel: "openai/gpt-5.5",
       apiKeys: [],
       isPro: true,
     });
 
-    assert.equal(result.providerId, "openai");
-    assert.equal(result.modelId, "gpt-5.5");
-    assert.equal(result.apiKey, "server-openai");
+    assert.equal(result.providerId, "openrouter");
+    assert.equal(result.modelId, "openai/gpt-5.5");
+    assert.equal(result.apiKey, "server-openrouter");
     assert.equal(result.usedServerKey, true);
     assert.equal(result.requiresRateLimit, true);
   });
@@ -102,7 +102,7 @@ describe("resolveAIRequest", () => {
   });
 
   it("reports server-key usage for every allowed server-key call", () => {
-    process.env.OPENAI_API_KEY = "server-openai";
+    process.env.OPENROUTER_API_KEY = "server-openrouter";
 
     const result = resolveAIRequest({
       requestedModel: "gpt-5.4-nano",
@@ -111,5 +111,7 @@ describe("resolveAIRequest", () => {
     });
 
     assert.equal(result.usedServerKey, true);
+    assert.equal(result.providerId, "openrouter");
+    assert.equal(result.modelId, "openai/gpt-5.6-luna");
   });
 });

--- a/src/lib/ai/task-models.test.ts
+++ b/src/lib/ai/task-models.test.ts
@@ -6,30 +6,30 @@ import type { AIConfig } from "@/lib/ai-models";
 
 describe("task model routing", () => {
   it("routes full resume tailoring by plan", () => {
-    assert.equal(getTaskModel("jobTailoring", false), "gpt-5.4-nano");
-    assert.equal(getTaskModel("jobTailoring", true), "gpt-5.5");
+    assert.equal(getTaskModel("jobTailoring", false), "openai/gpt-5.6-luna");
+    assert.equal(getTaskModel("jobTailoring", true), "openai/gpt-5.5");
   });
 
-  it("routes extraction and scoring to GPT-5.4 Nano", () => {
-    assert.equal(getTaskModel("structuredExtraction", false), "gpt-5.4-nano");
-    assert.equal(getTaskModel("structuredExtraction", true), "gpt-5.4-nano");
-    assert.equal(getTaskModel("resumeScoring", false), "gpt-5.4-nano");
-    assert.equal(getTaskModel("resumeScoring", true), "gpt-5.4-nano");
+  it("routes extraction and scoring to GPT-5.6 Luna through OpenRouter", () => {
+    assert.equal(getTaskModel("structuredExtraction", false), "openai/gpt-5.6-luna");
+    assert.equal(getTaskModel("structuredExtraction", true), "openai/gpt-5.6-luna");
+    assert.equal(getTaskModel("resumeScoring", false), "openai/gpt-5.6-luna");
+    assert.equal(getTaskModel("resumeScoring", true), "openai/gpt-5.6-luna");
   });
 
-  it("routes bullet generation and cover letters to GPT-5.4 Mini", () => {
-    assert.equal(getTaskModel("contentGeneration", false), "gpt-5.4-mini");
-    assert.equal(getTaskModel("contentGeneration", true), "gpt-5.4-mini");
-    assert.equal(getTaskModel("coverLetter", false), "gpt-5.4-mini");
-    assert.equal(getTaskModel("coverLetter", true), "gpt-5.4-mini");
+  it("routes bullet generation and cover letters to GPT-5.6 Luna", () => {
+    assert.equal(getTaskModel("contentGeneration", false), "openai/gpt-5.6-luna");
+    assert.equal(getTaskModel("contentGeneration", true), "openai/gpt-5.6-luna");
+    assert.equal(getTaskModel("coverLetter", false), "openai/gpt-5.6-luna");
+    assert.equal(getTaskModel("coverLetter", true), "openai/gpt-5.6-luna");
   });
 
-  it("routes free chat assistant to GPT-5.4 Nano", () => {
-    assert.equal(getTaskModel("chatAssistant", false), "gpt-5.4-nano");
-    assert.equal(getTaskModel("chatAssistant", true), "gpt-5.5");
+  it("routes chat assistants through OpenRouter", () => {
+    assert.equal(getTaskModel("chatAssistant", false), "openai/gpt-5.6-luna");
+    assert.equal(getTaskModel("chatAssistant", true), "openai/gpt-5.5");
   });
 
-  it("preserves API keys and custom prompts while replacing the model", () => {
+  it("honors a selected model while preserving API keys and custom prompts", () => {
     const config: AIConfig = {
       model: "claude-sonnet-4-6",
       apiKeys: [
@@ -46,22 +46,34 @@ describe("task model routing", () => {
       config,
     });
 
-    assert.equal(resolved.model, "gpt-5.4-nano");
+    assert.equal(resolved.model, "claude-sonnet-4-6");
     assert.deepEqual(resolved.apiKeys, config.apiKeys);
     assert.deepEqual(resolved.customPrompts, config.customPrompts);
   });
 
-  it("can intentionally preserve a selected model for future override paths", () => {
+  it("migrates a legacy selected OpenAI model to its OpenRouter equivalent", () => {
     const resolved = withTaskModel({
-      task: "chatAssistant",
-      isPro: true,
+      task: "structuredExtraction",
+      isPro: false,
       config: {
-        model: "claude-opus-4-7",
+        model: "gpt-5.4-nano",
         apiKeys: [],
       },
-      respectSelectedModel: true,
     });
 
-    assert.equal(resolved.model, "claude-opus-4-7");
+    assert.equal(resolved.model, "openai/gpt-5.6-luna");
+  });
+
+  it("uses the task default when no selected model is provided", () => {
+    const resolved = withTaskModel({
+      task: "chatAssistant",
+      isPro: false,
+      config: {
+        model: "  ",
+        apiKeys: [],
+      },
+    });
+
+    assert.equal(resolved.model, "openai/gpt-5.6-luna");
   });
 });

--- a/src/lib/ai/task-models.ts
+++ b/src/lib/ai/task-models.ts
@@ -1,4 +1,5 @@
 import {
+  getCanonicalModelId,
   MODEL_DESIGNATIONS,
   type AIConfig,
   type ApiKey,
@@ -18,7 +19,6 @@ interface TaskModelInput {
   config?: AIConfig;
   isPro: boolean;
   task: AITaskModel;
-  respectSelectedModel?: boolean;
 }
 
 interface TaskModelConfigParts {
@@ -57,10 +57,12 @@ export function getTaskModel(task: AITaskModel, isPro: boolean): string {
 }
 
 export function withTaskModel(input: TaskModelInput): AIConfig {
-  if (input.respectSelectedModel && input.config?.model) {
+  const selectedModel = input.config?.model?.trim();
+
+  if (selectedModel) {
     return {
       ...getConfigParts(input.config),
-      model: input.config.model,
+      model: getCanonicalModelId(selectedModel),
     };
   }
 

--- a/src/utils/actions/jobs/ai.ts
+++ b/src/utils/actions/jobs/ai.ts
@@ -8,6 +8,7 @@ import {
 } from "@/lib/zod-schemas";
 import { Job, Resume } from "@/lib/types";
 import { AIConfig } from '@/utils/ai-tools';
+import { MODEL_DESIGNATIONS } from '@/lib/ai-models';
 import { getSubscriptionPlan } from '../stripe/actions';
 import { dedupeAIConfigs, withTaskModel, type AITaskModel } from '@/lib/ai/task-models';
 import {
@@ -57,9 +58,7 @@ function getFallbackConfig(config: AIConfig | undefined, model: string): AIConfi
 function getModelCandidates(config: AIConfig | undefined, isPro: boolean, task: AITaskModel) {
   const primaryModel = withTaskModel({ task, isPro, config });
   const fallbackModels: AIConfig[] = [
-    getFallbackConfig(config, 'gpt-5.4-mini'),
-    getFallbackConfig(config, 'gpt-5.4-nano'),
-    getFallbackConfig(config, 'z-ai/glm-4.6:exacto'),
+    getFallbackConfig(config, MODEL_DESIGNATIONS.FAST_CHEAP),
     getFallbackConfig(config, 'openai/gpt-oss-120b'),
     getFallbackConfig(config, 'openai/gpt-oss-20b'),
     getFallbackConfig(config, 'deepseek/deepseek-v3.2:nitro'),


### PR DESCRIPTION
## Summary

- serve ResumeLM's app-funded GPT defaults through OpenRouter
- replace GPT-5.4 Nano/Mini task defaults with `openai/gpt-5.6-luna`
- keep the Pro default on GPT-5.5, now via `openai/gpt-5.5` on OpenRouter
- honor the model selected in the UI instead of silently overwriting it with a task default
- migrate legacy stored OpenAI model IDs to canonical OpenRouter IDs
- hide the unused direct OpenAI key form while retaining compatibility for custom/legacy deployments
- update setup documentation and fallback routing

## Why

Production AI requests were still routed to the direct OpenAI server key, which had exhausted credits. The UI model selector also appeared to change models while `withTaskModel` overwrote the selection on the server, so users could not escape the failing route.

## Validation

- 56 tests pass, including new routing and legacy-ID regression coverage
- TypeScript check passes
- ESLint passes on every changed source file
- Next.js production build passes with local placeholder service credentials

## Deployment note

The deployed environment must keep `OPENROUTER_API_KEY` configured. No database migration is required.