### PR TITLE
Fix Stripe subscription lifecycle event semantics

### DIFF
--- a/src/app/api/webhooks/stripe/route.ts
+++ b/src/app/api/webhooks/stripe/route.ts
@@ -6,6 +6,11 @@ import { manageSubscriptionStatusChange } from '@/utils/actions/stripe/actions'
 import { createServiceClient } from '@/utils/supabase/server'
 import { AnalyticsEvents } from '@/lib/analytics/events'
 import { captureServerAnalyticsEvent } from '@/lib/analytics/server'
+import {
+  getInvoiceSubscriptionId,
+  isFirstPaidInvoice,
+  shouldCaptureTrialStarted,
+} from '@/lib/stripe/billing-events'
 import type { Subscription } from '@/lib/types'
 
 const stripe = new Stripe(process.env.STRIPE_SECRET_KEY!, {
@@ -17,6 +22,7 @@ const webhookSecret = process.env.STRIPE_WEBHOOK_SECRET!
 const relevantEvents = new Set([
   'checkout.session.completed',
   'invoice.paid',
+  'invoice.payment_failed',
   'customer.subscription.created',
   'customer.subscription.updated',
   'customer.subscription.deleted',
@@ -164,32 +170,145 @@ function getSubscriptionEventProperties(
   };
 }
 
-async function captureSubscriptionLifecycleEvent(input: {
+async function captureTrialStartedEvent(input: {
   eventType: string;
+  subscription: Stripe.Subscription;
+  previousStatus?: Stripe.Subscription.Status;
+  subscriptionData: Partial<Subscription>;
+}) {
+  if (
+    !shouldCaptureTrialStarted({
+      eventType: input.eventType,
+      status: input.subscription.status,
+      previousStatus: input.previousStatus,
+    })
+  ) {
+    return;
+  }
+
+  const userId = input.subscriptionData.user_id;
+  if (!userId) return;
+
+  await captureServerAnalyticsEvent({
+    distinctId: userId,
+    event: AnalyticsEvents.TrialStarted,
+    insertId: `${input.subscription.id}:trial_started`,
+    properties: {
+      ...getSubscriptionEventProperties(input.subscriptionData, input.eventType),
+      trial_start: input.subscription.trial_start
+        ? new Date(input.subscription.trial_start * 1000).toISOString()
+        : null,
+      trial_end: input.subscription.trial_end
+        ? new Date(input.subscription.trial_end * 1000).toISOString()
+        : null,
+    },
+  });
+}
+
+async function captureSubscriptionCanceledEvent(input: {
+  eventType: string;
+  subscription: Stripe.Subscription;
+  subscriptionData: Partial<Subscription>;
+}) {
+  if (input.eventType !== 'customer.subscription.deleted') return;
+
+  const userId = input.subscriptionData.user_id;
+  if (!userId) return;
+
+  await captureServerAnalyticsEvent({
+    distinctId: userId,
+    event: AnalyticsEvents.SubscriptionCanceled,
+    insertId: `${input.subscription.id}:subscription_canceled`,
+    properties: {
+      ...getSubscriptionEventProperties(input.subscriptionData, input.eventType),
+      canceled_at: input.subscription.canceled_at
+        ? new Date(input.subscription.canceled_at * 1000).toISOString()
+        : null,
+      ended_at: input.subscription.ended_at
+        ? new Date(input.subscription.ended_at * 1000).toISOString()
+        : null,
+    },
+  });
+}
+
+async function captureInvoicePaymentFailedEvent(input: {
+  eventType: string;
+  invoice: Stripe.Invoice;
+  subscriptionData: Partial<Subscription>;
+}) {
+  if (input.eventType !== 'invoice.payment_failed') return;
+
+  const userId = input.subscriptionData.user_id;
+  if (!userId) return;
+
+  await captureServerAnalyticsEvent({
+    distinctId: userId,
+    event: AnalyticsEvents.InvoicePaymentFailed,
+    insertId: `${input.invoice.id}:invoice_payment_failed:${input.invoice.attempt_count ?? 'unknown'}`,
+    properties: {
+      ...getSubscriptionEventProperties(input.subscriptionData, input.eventType),
+      stripe_invoice_id: input.invoice.id,
+      amount_due: input.invoice.amount_due,
+      amount_remaining: input.invoice.amount_remaining,
+      currency: input.invoice.currency,
+      billing_reason: input.invoice.billing_reason,
+      attempt_count: input.invoice.attempt_count,
+      next_payment_attempt: input.invoice.next_payment_attempt
+        ? new Date(input.invoice.next_payment_attempt * 1000).toISOString()
+        : null,
+    },
+  });
+}
+
+async function captureFirstInvoicePaidEvent(input: {
+  invoice: InvoiceWithSubscription;
+  subscriptionId: string;
   subscriptionData: Partial<Subscription>;
 }) {
   const userId = input.subscriptionData.user_id;
   if (!userId) return;
 
-  if (
-    ['checkout.session.completed', 'customer.subscription.created'].includes(input.eventType) &&
-    input.subscriptionData.subscription_plan === 'pro' &&
-    input.subscriptionData.subscription_status === 'active'
-  ) {
-    await captureServerAnalyticsEvent({
-      distinctId: userId,
-      event: AnalyticsEvents.SubscriptionActivated,
-      properties: getSubscriptionEventProperties(input.subscriptionData, input.eventType),
+  let paidSubscriptionInvoices: Stripe.Invoice[];
+  try {
+    const invoices = await stripe.invoices.list({
+      subscription: input.subscriptionId,
+      status: 'paid',
+      limit: 100,
     });
+    paidSubscriptionInvoices = invoices.data;
+  } catch (error) {
+    // Leave this webhook unprocessed so Stripe retries if the history query is
+    // temporarily unavailable. The stable PostHog insert id keeps a retry
+    // from creating a duplicate lifecycle event.
+    console.warn('Unable to determine first paid invoice', {
+      invoiceId: input.invoice.id,
+      subscriptionId: input.subscriptionId,
+      error: error instanceof Error ? error.message : 'Unknown error',
+    });
+    throw error;
   }
 
-  if (input.subscriptionData.subscription_status === 'canceled') {
-    await captureServerAnalyticsEvent({
-      distinctId: userId,
-      event: AnalyticsEvents.SubscriptionCanceled,
-      properties: getSubscriptionEventProperties(input.subscriptionData, input.eventType),
-    });
+  if (
+    !isFirstPaidInvoice({
+      invoice: input.invoice,
+      paidSubscriptionInvoices,
+    })
+  ) {
+    return;
   }
+
+  await captureServerAnalyticsEvent({
+    distinctId: userId,
+    event: AnalyticsEvents.FirstInvoicePaid,
+    insertId: `${input.invoice.id}:first_invoice_paid`,
+    properties: {
+      ...getSubscriptionEventProperties(input.subscriptionData, 'invoice.paid'),
+      stripe_invoice_id: input.invoice.id,
+      amount_paid: input.invoice.amount_paid,
+      currency: input.invoice.currency,
+      billing_reason: input.invoice.billing_reason,
+    },
+  });
 }
 
 export async function POST(req: Request) {
@@ -288,25 +407,40 @@ export async function POST(req: Request) {
               properties: getSubscriptionEventProperties(subscriptionData, event.type),
             });
           }
-          await captureSubscriptionLifecycleEvent({
-            eventType: event.type,
-            subscriptionData,
-          });
         }
         break;
       }
 
       case 'invoice.paid': {
         const invoice = event.data.object as InvoiceWithSubscription;
-        const subscriptionId = getSubscriptionId(invoice.subscription);
+        const subscriptionId = getInvoiceSubscriptionId(invoice);
         
         if (subscriptionId) {
           const subscriptionData = await handleSubscriptionChange(
             getCustomerId(invoice.customer as string | Stripe.Customer | Stripe.DeletedCustomer | null),
             subscriptionId
           );
-          await captureSubscriptionLifecycleEvent({
+          await captureFirstInvoicePaidEvent({
+            invoice,
+            subscriptionId,
+            subscriptionData,
+          });
+        }
+        break;
+      }
+
+      case 'invoice.payment_failed': {
+        const invoice = event.data.object as InvoiceWithSubscription;
+        const subscriptionId = getInvoiceSubscriptionId(invoice);
+
+        if (subscriptionId) {
+          const subscriptionData = await handleSubscriptionChange(
+            getCustomerId(invoice.customer as string | Stripe.Customer | Stripe.DeletedCustomer | null),
+            subscriptionId
+          );
+          await captureInvoicePaymentFailedEvent({
             eventType: event.type,
+            invoice,
             subscriptionData,
           });
         }
@@ -352,8 +486,10 @@ export async function POST(req: Request) {
           getCustomerId(subscription.customer),
           subscription.id
         );
-        await captureSubscriptionLifecycleEvent({
+        await captureTrialStartedEvent({
           eventType: event.type,
+          subscription,
+          previousStatus: previousAttributes.status,
           subscriptionData,
         });
         break;
@@ -374,8 +510,9 @@ export async function POST(req: Request) {
           getCustomerId(subscription.customer),
           subscription.id
         );
-        await captureSubscriptionLifecycleEvent({
+        await captureSubscriptionCanceledEvent({
           eventType: event.type,
+          subscription,
           subscriptionData,
         });
         console.log('✅ Subscription deletion processed successfully');
@@ -396,17 +533,6 @@ export async function POST(req: Request) {
           console.log('🗑️ Deleted subscription record for customer:', {
             customerId: customer.id,
             supabaseUUID: customer.metadata.supabaseUUID
-          });
-          await captureServerAnalyticsEvent({
-            distinctId: customer.metadata.supabaseUUID,
-            event: AnalyticsEvents.SubscriptionCanceled,
-            properties: {
-              stripe_subscription_id: null,
-              subscription_status: 'canceled',
-              subscription_plan: null,
-              current_period_end: null,
-              event_type: event.type,
-            },
           });
         } catch (error) {
           console.error('❌ Failed to clear Stripe customer data:', error);

--- a/src/lib/analytics/events.test.ts
+++ b/src/lib/analytics/events.test.ts
@@ -18,8 +18,11 @@ describe("AnalyticsEvents", () => {
     assert.equal(AnalyticsEvents.AIRequestFailed, "ai_request_failed");
     assert.equal(AnalyticsEvents.CheckoutStarted, "checkout_started");
     assert.equal(AnalyticsEvents.CheckoutCompleted, "checkout_completed");
-    assert.equal(AnalyticsEvents.SubscriptionActivated, "subscription_activated");
+    assert.equal(AnalyticsEvents.TrialStarted, "trial_started");
+    assert.equal(AnalyticsEvents.FirstInvoicePaid, "first_invoice_paid");
+    assert.equal(AnalyticsEvents.InvoicePaymentFailed, "invoice_payment_failed");
     assert.equal(AnalyticsEvents.SubscriptionCanceled, "subscription_canceled");
+    assert.equal(Object.hasOwn(AnalyticsEvents, "SubscriptionActivated"), false);
   });
 });
 
@@ -82,6 +85,18 @@ describe("buildAnalyticsPayload", () => {
           resume_type: "base",
         },
       }
+    );
+  });
+
+  it("passes a stable insert id when server events need logical deduplication", () => {
+    assert.equal(
+      buildAnalyticsPayload({
+        apiKey: "ph_key",
+        distinctId: "user_123",
+        event: AnalyticsEvents.FirstInvoicePaid,
+        insertId: "in_123:first_invoice_paid",
+      }).properties.$insert_id,
+      "in_123:first_invoice_paid"
     );
   });
 });

--- a/src/lib/analytics/events.ts
+++ b/src/lib/analytics/events.ts
@@ -8,7 +8,9 @@ export const AnalyticsEvents = {
   AIRequestFailed: "ai_request_failed",
   CheckoutStarted: "checkout_started",
   CheckoutCompleted: "checkout_completed",
-  SubscriptionActivated: "subscription_activated",
+  TrialStarted: "trial_started",
+  FirstInvoicePaid: "first_invoice_paid",
+  InvoicePaymentFailed: "invoice_payment_failed",
   SubscriptionCanceled: "subscription_canceled",
 } as const;
 
@@ -50,6 +52,7 @@ export function buildAnalyticsPayload(input: {
   apiKey: string;
   distinctId: string;
   event: AnalyticsEventName;
+  insertId?: string;
   properties?: AnalyticsProperties;
 }) {
   return {
@@ -59,6 +62,7 @@ export function buildAnalyticsPayload(input: {
     properties: {
       ...sanitizeAnalyticsProperties(input.properties),
       $geoip_disable: true,
+      ...(input.insertId ? { $insert_id: input.insertId } : {}),
     },
   };
 }

--- a/src/lib/analytics/server.ts
+++ b/src/lib/analytics/server.ts
@@ -17,6 +17,7 @@ function getCaptureUrl() {
 export async function captureServerAnalyticsEvent(input: {
   distinctId: string | null | undefined;
   event: AnalyticsEventName;
+  insertId?: string;
   properties?: AnalyticsProperties;
 }) {
   if (!posthogKey || !input.distinctId) return;
@@ -32,6 +33,7 @@ export async function captureServerAnalyticsEvent(input: {
           apiKey: posthogKey,
           distinctId: input.distinctId,
           event: input.event,
+          insertId: input.insertId,
           properties: input.properties,
         })
       ),

--- a/src/lib/stripe/billing-events.test.ts
+++ b/src/lib/stripe/billing-events.test.ts
@@ -1,0 +1,115 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+
+import {
+  getInvoiceSubscriptionId,
+  isFirstPaidInvoice,
+  shouldCaptureTrialStarted,
+} from "./billing-events";
+
+function invoice(overrides: Record<string, unknown> = {}) {
+  return {
+    id: "in_current",
+    status: "paid" as const,
+    amount_paid: 2000,
+    billing_reason: "subscription_create" as const,
+    ...overrides,
+  };
+}
+
+describe("Stripe billing lifecycle event classification", () => {
+  it("captures a trial only when Stripe enters trialing", () => {
+    assert.equal(
+      shouldCaptureTrialStarted({
+        eventType: "customer.subscription.created",
+        status: "trialing",
+      }),
+      true
+    );
+    assert.equal(
+      shouldCaptureTrialStarted({
+        eventType: "customer.subscription.updated",
+        status: "trialing",
+        previousStatus: "incomplete",
+      }),
+      true
+    );
+    assert.equal(
+      shouldCaptureTrialStarted({
+        eventType: "customer.subscription.updated",
+        status: "trialing",
+        previousStatus: "trialing",
+      }),
+      false
+    );
+    assert.equal(
+      shouldCaptureTrialStarted({
+        eventType: "customer.subscription.updated",
+        status: "trialing",
+      }),
+      false
+    );
+    assert.equal(
+      shouldCaptureTrialStarted({
+        eventType: "customer.subscription.created",
+        status: "active",
+      }),
+      false
+    );
+  });
+
+  it("treats the first positive subscription invoice as paid conversion", () => {
+    assert.equal(
+      isFirstPaidInvoice({ invoice: invoice(), paidSubscriptionInvoices: [] }),
+      true
+    );
+    assert.equal(
+      isFirstPaidInvoice({
+        invoice: invoice({ billing_reason: "subscription_cycle" }),
+        paidSubscriptionInvoices: [invoice({ id: "in_trial_zero", amount_paid: 0 })],
+      }),
+      true
+    );
+    assert.equal(
+      isFirstPaidInvoice({
+        invoice: invoice(),
+        paidSubscriptionInvoices: [invoice({ id: "in_previous" })],
+      }),
+      false
+    );
+    assert.equal(
+      isFirstPaidInvoice({
+        invoice: invoice({ amount_paid: 0 }),
+        paidSubscriptionInvoices: [],
+      }),
+      false
+    );
+    assert.equal(
+      isFirstPaidInvoice({
+        invoice: invoice({ billing_reason: "subscription_update" }),
+        paidSubscriptionInvoices: [],
+      }),
+      false
+    );
+  });
+
+  it("supports both current and legacy Stripe invoice subscription shapes", () => {
+    assert.equal(
+      getInvoiceSubscriptionId(
+        invoice({ subscription: "sub_legacy" }) as never
+      ),
+      "sub_legacy"
+    );
+    assert.equal(
+      getInvoiceSubscriptionId(
+        invoice({
+          parent: {
+            type: "subscription_details",
+            subscription_details: { subscription: "sub_current" },
+          },
+        }) as never
+      ),
+      "sub_current"
+    );
+  });
+});

--- a/src/lib/stripe/billing-events.ts
+++ b/src/lib/stripe/billing-events.ts
@@ -1,0 +1,79 @@
+import type Stripe from "stripe";
+
+type InvoiceWithLegacySubscription = Stripe.Invoice & {
+  /** `subscription` was present on older Stripe API versions. */
+  subscription?: string | Stripe.Subscription | null;
+};
+
+const FIRST_PAID_INVOICE_REASONS = new Set<Stripe.Invoice.BillingReason>([
+  "subscription_create",
+  "subscription_cycle",
+]);
+
+export function getInvoiceSubscriptionId(
+  invoice: InvoiceWithLegacySubscription
+): string | null {
+  if (invoice.subscription) {
+    return typeof invoice.subscription === "string"
+      ? invoice.subscription
+      : invoice.subscription.id;
+  }
+
+  const subscriptionDetails =
+    invoice.parent?.type === "subscription_details"
+      ? invoice.parent.subscription_details
+      : null;
+
+  if (!subscriptionDetails?.subscription) {
+    return null;
+  }
+
+  return typeof subscriptionDetails.subscription === "string"
+    ? subscriptionDetails.subscription
+    : subscriptionDetails.subscription.id;
+}
+
+export function shouldCaptureTrialStarted(input: {
+  eventType: string;
+  status: Stripe.Subscription.Status;
+  previousStatus?: Stripe.Subscription.Status;
+}): boolean {
+  if (input.status !== "trialing") {
+    return false;
+  }
+
+  if (input.eventType === "customer.subscription.created") {
+    return true;
+  }
+
+  return (
+    input.eventType === "customer.subscription.updated" &&
+    input.previousStatus !== undefined &&
+    input.previousStatus !== "trialing"
+  );
+}
+
+export function isFirstPaidInvoice(input: {
+  invoice: Pick<Stripe.Invoice, "id" | "status" | "amount_paid" | "billing_reason">;
+  paidSubscriptionInvoices: Array<
+    Pick<Stripe.Invoice, "id" | "status" | "amount_paid">
+  >;
+}): boolean {
+  const { invoice } = input;
+
+  if (
+    invoice.status !== "paid" ||
+    invoice.amount_paid <= 0 ||
+    !invoice.billing_reason ||
+    !FIRST_PAID_INVOICE_REASONS.has(invoice.billing_reason)
+  ) {
+    return false;
+  }
+
+  return !input.paidSubscriptionInvoices.some(
+    (candidate) =>
+      candidate.id !== invoice.id &&
+      candidate.status === "paid" &&
+      candidate.amount_paid > 0
+  );
+}


### PR DESCRIPTION
## What changed

- Remove the duplicated `subscription_activated` analytics event.
- Emit `trial_started` only when Stripe enters `trialing` from `customer.subscription.created` or a real status transition.
- Emit `first_invoice_paid` from `invoice.paid` only for the first positive subscription invoice, including trial-to-paid conversion.
- Emit `invoice_payment_failed` from `invoice.payment_failed`.
- Emit `subscription_canceled` only from `customer.subscription.deleted`, not from scheduled cancellation updates or customer deletion.
- Add Stripe invoice subscription-shape compatibility and stable PostHog `$insert_id` values for logical deduplication.

## Why

The old handler treated Stripe `trialing` as app `active` and emitted `subscription_activated` from both Checkout completion and subscription creation. Live evidence showed one July trial creating two activation events, while no invoice-paid or payment-failed lifecycle events existed. That made trial starts look like sales and left payment failures invisible.

## Validation

- `tsc --noEmit --pretty false`
- `npm test -- --test-reporter=dot` (61 passing)
- `npm run lint`
- Production build with placeholder runtime variables
