### PR TITLE
Fix OAuth signup intent and session persistence

### DIFF
--- a/src/app/auth/callback/route.ts
+++ b/src/app/auth/callback/route.ts
@@ -1,41 +1,105 @@
-
-import { createClient } from '@/utils/supabase/server'
+import { createServerClient, type CookieOptions } from '@supabase/ssr'
 import { NextRequest, NextResponse } from 'next/server'
 
-function getSafeRedirectPath(path: string | null, fallback = '/') {
-  if (!path) return fallback
-  if (!path.startsWith('/')) return fallback
-  if (path.startsWith('//')) return fallback
-  return path
+import {
+  AUTH_ERROR_CODES,
+  addAuthIntentToUrl,
+  classifyOAuthError,
+  getAuthIntentFromSearchParams,
+  getAuthRedirectPath,
+  type AuthIntent,
+} from '@/lib/auth-intent'
+
+type PendingCookie = {
+  name: string
+  value: string
+  options: CookieOptions
+}
+
+function redirectToLogin(
+  requestUrl: URL,
+  intent: AuthIntent,
+  errorCode: string,
+  pendingCookies: PendingCookie[] = [],
+) {
+  const errorUrl = new URL('/auth/login', requestUrl.origin)
+  errorUrl.searchParams.set('error', errorCode)
+  addAuthIntentToUrl(errorUrl, intent)
+  const response = NextResponse.redirect(errorUrl)
+  pendingCookies.forEach(({ name, value, options }) => response.cookies.set(name, value, options))
+  return response
+}
+
+function logCallbackFailure(details: Record<string, unknown>) {
+  console.error('Google OAuth callback failed:', details)
 }
 
 export async function GET(request: NextRequest) {
   const requestUrl = new URL(request.url)
+  const intent = getAuthIntentFromSearchParams(requestUrl.searchParams)
+  const providerError = requestUrl.searchParams.get('error')
+  const providerErrorCode = requestUrl.searchParams.get('error_code')
+  const providerErrorDescription = requestUrl.searchParams.get('error_description')
   const code = requestUrl.searchParams.get('code')
-  const next = requestUrl.searchParams.get('next')
 
-  if (!code) {
-    const errorUrl = new URL('/auth/login', requestUrl.origin)
-    errorUrl.searchParams.set('error', 'auth_code_missing')
-    return NextResponse.redirect(errorUrl)
+  if (providerError) {
+    const errorCode = classifyOAuthError({ providerError })
+    logCallbackFailure({
+      errorCode,
+      providerError,
+      providerErrorCode,
+      providerErrorDescription,
+      next: intent.next ?? null,
+      plan: intent.plan ?? null,
+    })
+    return redirectToLogin(requestUrl, intent, errorCode)
   }
 
-  const supabase = await createClient()
+  if (!code) {
+    logCallbackFailure({
+      errorCode: AUTH_ERROR_CODES.oauthMissingCode,
+      next: intent.next ?? null,
+      plan: intent.plan ?? null,
+    })
+    return redirectToLogin(requestUrl, intent, AUTH_ERROR_CODES.oauthMissingCode)
+  }
+
+  const pendingCookies: PendingCookie[] = []
+  const supabase = createServerClient(
+    process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
+    {
+      cookies: {
+        getAll() {
+          return request.cookies.getAll()
+        },
+        setAll(cookiesToSet) {
+          cookiesToSet.forEach(({ name, value }) => request.cookies.set(name, value))
+          pendingCookies.push(...cookiesToSet)
+        },
+      },
+    }
+  )
+
   const { error } = await supabase.auth.exchangeCodeForSession(code)
 
   if (error) {
-    console.error('OAuth callback failed:', error.message)
-    const errorUrl = new URL('/auth/login', requestUrl.origin)
-    errorUrl.searchParams.set('error', 'auth_callback_failed')
-    return NextResponse.redirect(errorUrl)
+    const errorCode = classifyOAuthError({ message: error.message })
+    logCallbackFailure({
+      errorCode,
+      supabaseCode: error.code ?? null,
+      message: error.message,
+      status: error.status ?? null,
+      name: error.name,
+      next: intent.next ?? null,
+      plan: intent.plan ?? null,
+    })
+    return redirectToLogin(requestUrl, intent, errorCode, pendingCookies)
   }
 
-  // URL to redirect to after sign in process completes
-  // If 'next' is provided and is a relative path, use it.
-  // Otherwise, default to the root.
-  const redirectPath = getSafeRedirectPath(next)
-  
-  // Construct the full redirect URL
-  return NextResponse.redirect(new URL(redirectPath, requestUrl.origin))
-} 
+  const redirectPath = getAuthRedirectPath(intent)
+  const response = NextResponse.redirect(new URL(redirectPath, requestUrl.origin))
+  pendingCookies.forEach(({ name, value, options }) => response.cookies.set(name, value, options))
 
+  return response
+}

--- a/src/app/auth/login/actions.ts
+++ b/src/app/auth/login/actions.ts
@@ -9,16 +9,23 @@ import type { AuthFormState } from "@/components/auth/auth-form-state";
 import { AnalyticsEvents } from "@/lib/analytics/events";
 import { captureServerAnalyticsEvent } from "@/lib/analytics/server";
 import { getEmailSignupBlockedMessage, isEmailSignupAllowed } from "@/lib/auth-policy";
+import {
+  AUTH_ERROR_CODES,
+  buildAuthCallbackUrl,
+  getSafeRedirectPath,
+  type AuthIntent,
+} from "@/lib/auth-intent";
 
 // Auto-create Pro subscription for new users (for local development)
 const AUTO_PRO_SUBSCRIPTION = process.env.AUTO_PRO_SUBSCRIPTION === 'true';
 
-interface AuthResult {
+export interface AuthResult {
   success: boolean;
   error?: string;
+  errorCode?: string;
 }
 
-interface OAuthAuthResult extends AuthResult {
+export interface OAuthAuthResult extends AuthResult {
   url?: string;
 }
 
@@ -51,7 +58,8 @@ export async function login(formData: FormData): Promise<AuthResult> {
     return { success: false, error: error.message }
   }
 
-  redirect('/')
+  const next = getSafeRedirectPath(formData.get('next') as string | null);
+  redirect(next)
   return { success: true }
 }
 
@@ -206,35 +214,50 @@ export async function resetPasswordForEmail(formData: FormData): Promise<AuthRes
 } 
 
 // Google Sign In
-export async function signInWithGoogle(): Promise<OAuthAuthResult> {
+export async function signInWithGoogle(intent?: AuthIntent): Promise<OAuthAuthResult> {
   const supabase = await createClient();
 
   try {
     const { data, error } = await supabase.auth.signInWithOAuth({
       provider: 'google',
       options: {
-        redirectTo: `${process.env.NEXT_PUBLIC_SITE_URL}/auth/callback`,
-        queryParams: {
-          next: '/',
-          access_type: 'offline',
-          prompt: 'consent',
-        }
+        redirectTo: buildAuthCallbackUrl(process.env.NEXT_PUBLIC_SITE_URL!, intent),
       }
     });
 
     if (error) {
-      return { success: false, error: error.message };
+      console.error('Google OAuth start failed:', {
+        code: error.code ?? null,
+        message: error.message,
+        status: error.status ?? null,
+        name: error.name,
+      });
+      return {
+        success: false,
+        error: 'Unable to start Google sign-in. Please try again.',
+        errorCode: AUTH_ERROR_CODES.oauthStartFailed,
+      };
     }
 
     if (data?.url) {
       return { success: true, url: data.url };
     }
 
-    return { success: false, error: 'Failed to get OAuth URL' };
+    console.error('Google OAuth start returned no URL');
+    return {
+      success: false,
+      error: 'Unable to start Google sign-in. Please try again.',
+      errorCode: AUTH_ERROR_CODES.oauthStartFailed,
+    };
   } catch (error) {
+    console.error('Google OAuth start threw:', {
+      message: error instanceof Error ? error.message : String(error),
+      name: error instanceof Error ? error.name : undefined,
+    });
     return { 
       success: false, 
-      error: error instanceof Error ? error.message : 'An unexpected error occurred' 
+      error: 'Unable to start Google sign-in. Please try again.',
+      errorCode: AUTH_ERROR_CODES.oauthStartFailed,
     };
   }
 } 

--- a/src/app/auth/login/page.tsx
+++ b/src/app/auth/login/page.tsx
@@ -14,6 +14,7 @@ import { SplitContent } from "@/components/ui/split-content";
 import { NavLinks } from "@/components/layout/nav-links";
 import { ModelShowcase } from "@/components/landing/model-showcase";
 import { AuthDialogProvider } from "@/components/auth/auth-dialog-provider";
+import { AUTH_ERROR_CODES, getAuthIntentFromParams } from "@/lib/auth-intent";
 
 // import { WaitlistSection } from "@/components/waitlist/waitlist-section";
 
@@ -67,14 +68,18 @@ export default async function LoginPage({
   searchParams: Promise<{ [key: string]: string | undefined }>;
 }) {
   const params = await searchParams;
+  const initialIntent = getAuthIntentFromParams(params);
   const showErrorDialog =
-    params?.error === 'email_confirmation' ||
-    params?.error === 'auth_code_missing' ||
-    params?.error === 'auth_callback_failed';
+    params?.error === AUTH_ERROR_CODES.emailConfirmation ||
+    params?.error === AUTH_ERROR_CODES.oauthMissingCode ||
+    params?.error === AUTH_ERROR_CODES.oauthProviderDenied ||
+    params?.error === AUTH_ERROR_CODES.oauthProviderError ||
+    params?.error === AUTH_ERROR_CODES.oauthStateMismatch ||
+    params?.error === AUTH_ERROR_CODES.oauthExchangeFailed;
 
   return (
     <>
-      <AuthDialogProvider>
+      <AuthDialogProvider initialIntent={initialIntent}>
         <main className="relative overflow-x-hidden selection:bg-violet-200/50 ">
           {/* Error Dialog */}
           <ErrorDialog isOpen={!!showErrorDialog} />

--- a/src/components/auth/auth-dialog-provider.tsx
+++ b/src/components/auth/auth-dialog-provider.tsx
@@ -10,11 +10,12 @@ import { Button } from "@/components/ui/button";
 import { Dialog, DialogContent, DialogDescription, DialogTitle } from "@/components/ui/dialog";
 import { Separator } from "@/components/ui/separator";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import type { AuthIntent } from "@/lib/auth-intent";
 
 export type AuthTab = "login" | "signup";
 
 interface AuthDialogContextValue {
-  openDialog: (tab?: AuthTab) => void;
+  openDialog: (tab?: AuthTab, intent?: AuthIntent) => void;
 }
 
 const AuthDialogContext = createContext<AuthDialogContextValue | undefined>(undefined);
@@ -38,7 +39,7 @@ function TabButton({ value, children }: { value: AuthTab; children: React.ReactN
   );
 }
 
-function SocialAuth({ showDivider = true }: { showDivider?: boolean }) {
+function SocialAuth({ showDivider = true, intent }: { showDivider?: boolean; intent?: AuthIntent }) {
   const [isLoading, setIsLoading] = useState(false);
   const [errorMessage, setErrorMessage] = useState<string>();
 
@@ -47,7 +48,7 @@ function SocialAuth({ showDivider = true }: { showDivider?: boolean }) {
 
     try {
       setIsLoading(true);
-      const result = await signInWithGoogle();
+      const result = await signInWithGoogle(intent);
 
       if (!result.success) {
         const message = result.error || "Failed to sign in with Google.";
@@ -117,25 +118,34 @@ function SocialAuth({ showDivider = true }: { showDivider?: boolean }) {
   );
 }
 
-export function AuthDialogProvider({ children }: { children: React.ReactNode }) {
+export function AuthDialogProvider({
+  children,
+  initialIntent,
+}: {
+  children: React.ReactNode;
+  initialIntent?: AuthIntent;
+}) {
   const [open, setOpen] = useState(false);
   const [activeTab, setActiveTab] = useState<AuthTab>("signup");
   const [formVersion, setFormVersion] = useState(0);
+  const [intent, setIntent] = useState<AuthIntent | undefined>(initialIntent);
 
   const resetDialog = useCallback(() => {
     setActiveTab("signup");
+    setIntent(initialIntent);
     setFormVersion((version) => version + 1);
-  }, []);
+  }, [initialIntent]);
 
   const closeDialog = useCallback(() => {
     setOpen(false);
     resetDialog();
   }, [resetDialog]);
 
-  const openDialog = useCallback((tab: AuthTab = "signup") => {
+  const openDialog = useCallback((tab: AuthTab = "signup", nextIntent?: AuthIntent) => {
     setActiveTab(tab);
+    setIntent(nextIntent ?? initialIntent);
     setOpen(true);
-  }, []);
+  }, [initialIntent]);
 
   const handleOpenChange = useCallback(
     (isOpen: boolean) => {
@@ -189,8 +199,8 @@ export function AuthDialogProvider({ children }: { children: React.ReactNode }) 
                     <h3 className="text-lg font-semibold text-slate-900">Welcome back</h3>
                     <p className="text-sm text-slate-600 mt-1">Sign in to continue</p>
                   </div>
-                  <LoginForm key={`login-${formVersion}`} />
-                  <SocialAuth />
+                  <LoginForm key={`login-${formVersion}`} next={intent?.next} />
+                  <SocialAuth intent={intent} />
                 </TabsContent>
 
                 <TabsContent value="signup" className="mt-0 space-y-4">
@@ -198,7 +208,7 @@ export function AuthDialogProvider({ children }: { children: React.ReactNode }) 
                     <h3 className="text-lg font-semibold text-slate-900">Get started</h3>
                     <p className="text-sm text-slate-600 mt-1">Create your free account with Google</p>
                   </div>
-                  <SocialAuth showDivider={false} />
+                  <SocialAuth showDivider={false} intent={intent} />
                 </TabsContent>
               </div>
             </Tabs>

--- a/src/components/auth/auth-dialog.tsx
+++ b/src/components/auth/auth-dialog.tsx
@@ -5,6 +5,7 @@ import { ArrowRight } from "lucide-react";
 
 import { Button } from "@/components/ui/button";
 import { AuthTab, useAuthDialog } from "@/components/auth/auth-dialog-provider";
+import type { AuthPlan } from "@/lib/auth-intent";
 
 const gradientClasses = {
   base: "bg-gradient-to-r from-violet-600 via-blue-600 to-violet-600",
@@ -15,13 +16,20 @@ const gradientClasses = {
 interface AuthDialogProps {
   children?: React.ReactNode;
   defaultTab?: AuthTab;
+  next?: string;
+  plan?: AuthPlan;
 }
 
-export function AuthDialog({ children, defaultTab = "signup" }: AuthDialogProps) {
+export function AuthDialog({
+  children,
+  defaultTab = "signup",
+  next = "/home",
+  plan,
+}: AuthDialogProps) {
   const { openDialog } = useAuthDialog();
 
   const handleOpen = () => {
-    openDialog(defaultTab);
+    openDialog(defaultTab, { next, plan });
   };
 
   if (!children) {

--- a/src/components/auth/error-dialog.tsx
+++ b/src/components/auth/error-dialog.tsx
@@ -12,6 +12,7 @@ import { AlertCircle } from "lucide-react";
 import Link from "next/link";
 import { useState, useEffect } from "react";
 import { useSearchParams } from "next/navigation";
+import { AUTH_ERROR_CODES } from "@/lib/auth-intent";
 
 interface ErrorDialogProps {
   isOpen: boolean;
@@ -26,12 +27,27 @@ export function ErrorDialog({ isOpen: initialIsOpen }: ErrorDialogProps) {
     setIsOpen(initialIsOpen);
   }, [initialIsOpen]);
 
-  const isSignInError = error === 'auth_code_missing' || error === 'auth_callback_failed';
+  const isSignInError = error !== AUTH_ERROR_CODES.emailConfirmation;
   const errorMessage = isOpen
-    ? isSignInError
-      ? 'We could not complete your sign-in. Please try again.'
-      : 'There was an issue with your email confirmation. Please check your inbox and try again.'
+    ? error === AUTH_ERROR_CODES.oauthMissingCode
+      ? 'Google did not return an authorization code. Please start sign-in again.'
+      : error === AUTH_ERROR_CODES.oauthProviderDenied
+        ? 'Google sign-in was cancelled. You can try again whenever you are ready.'
+        : error === AUTH_ERROR_CODES.oauthStateMismatch
+          ? 'This sign-in session expired or was already used. Please start again.'
+          : error === AUTH_ERROR_CODES.oauthProviderError
+            ? 'Google could not complete the sign-in request. Please try again.'
+            : error === AUTH_ERROR_CODES.oauthExchangeFailed
+              ? 'We could not finish your sign-in. Please try again.'
+              : 'There was an issue with your email confirmation. Please check your inbox and try again.'
     : null;
+
+  const retryParams = new URLSearchParams();
+  const next = searchParams.get('next');
+  const plan = searchParams.get('plan');
+  if (next) retryParams.set('next', next);
+  if (plan) retryParams.set('plan', plan);
+  const retryHref = `/auth/login${retryParams.toString() ? `?${retryParams.toString()}` : ''}`;
 
   return (
     <Dialog 
@@ -58,9 +74,9 @@ export function ErrorDialog({ isOpen: initialIsOpen }: ErrorDialogProps) {
           <ul className="list-disc list-inside space-y-2 text-muted-foreground">
             {isSignInError ? (
               <>
-                <li>The sign-in session expired</li>
-                <li>The browser returned without an authorization code</li>
-                <li>The OAuth provider configuration needs another look</li>
+                <li>The sign-in session expired or was already used</li>
+                <li>Google sign-in was cancelled or returned an error</li>
+                <li>The authorization exchange could not be completed</li>
               </>
             ) : (
               <>
@@ -71,7 +87,7 @@ export function ErrorDialog({ isOpen: initialIsOpen }: ErrorDialogProps) {
             )}
           </ul>
           <div className="pt-4 space-y-2">
-            <Link href="/">
+            <Link href={retryHref}>
               <Button className="w-full bg-gradient-to-r from-red-600 to-rose-600 text-white">
                 Try Logging In Again
               </Button>

--- a/src/components/auth/login-form.tsx
+++ b/src/components/auth/login-form.tsx
@@ -33,7 +33,7 @@ function SubmitButton() {
   );
 }
 
-export function LoginForm() {
+export function LoginForm({ next }: { next?: string }) {
   const [state, formAction] = useActionState(loginWithState, initialAuthFormState);
   const [showPassword, setShowPassword] = useState(false);
 
@@ -42,6 +42,7 @@ export function LoginForm() {
 
   return (
     <form action={formAction} className="space-y-5">
+      {next && <input type="hidden" name="next" value={next} />}
       <div className="space-y-2">
         <Label htmlFor="login-email" className="text-sm font-medium">
           Email

--- a/src/components/landing/PricingPlans.tsx
+++ b/src/components/landing/PricingPlans.tsx
@@ -11,6 +11,7 @@ interface PlanFeature {
 }
 
 interface PricingPlan {
+  plan: "free" | "pro";
   name: string;
   price: string;
   period?: string;
@@ -31,6 +32,7 @@ export function PricingPlans() {
   // Define pricing plans data for easier maintenance
   const plans = useMemo<PricingPlan[]>(() => [
     {
+      plan: "free",
       name: "Free",
       price: "$0",
       description: "Self-host or use with your own API keys",
@@ -45,6 +47,7 @@ export function PricingPlans() {
       ctaSecondary: true,
     },
     {
+      plan: "pro",
       name: "Pro",
       price: "$20",
       period: "/month",
@@ -179,7 +182,7 @@ export function PricingPlans() {
             <p className="text-muted-foreground mt-2 mb-6">{plan.description}</p>
             
             {/* CTA button */}
-            <AuthDialog>
+            <AuthDialog next={plan.plan === "pro" ? "/subscription" : "/home"} plan={plan.plan}>
               <button 
                 className={`
                   block w-full py-3 rounded-lg font-medium text-center transition-all duration-300 hover:-translate-y-1 mb-8
@@ -211,4 +214,4 @@ export function PricingPlans() {
   );
 }
 
-export default PricingPlans; 
+export default PricingPlans;

--- a/src/components/landing/pricing-section.tsx
+++ b/src/components/landing/pricing-section.tsx
@@ -9,6 +9,7 @@ interface PricingFeature {
 }
 
 interface PricingTier {
+  plan: "free" | "pro";
   name: string;
   price: string;
   description: string;
@@ -20,6 +21,7 @@ interface PricingTier {
 
 const tiers: PricingTier[] = [
   {
+    plan: "free",
     name: "Free",
     price: "$0",
     description: "Self-host or use with your own API keys",
@@ -33,6 +35,7 @@ const tiers: PricingTier[] = [
     buttonText: "Get Started",
   },
   {
+    plan: "pro",
     name: "Pro",
     price: "$20",
     description: "Enhanced features for serious job seekers",
@@ -137,7 +140,7 @@ export function PricingSection() {
                   ))}
                 </ul>
 
-                <AuthDialog>
+                <AuthDialog next={tier.plan === "pro" ? "/subscription" : "/home"} plan={tier.plan}>
                   <Button
                     className={cn(
                       "w-full bg-gradient-to-r text-white shadow-lg hover:shadow-xl transition-all duration-500 h-12 text-base",
@@ -154,4 +157,4 @@ export function PricingSection() {
       </div>
     </section>
   );
-} 
+}

--- a/src/lib/auth-intent.test.ts
+++ b/src/lib/auth-intent.test.ts
@@ -1,0 +1,60 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  AUTH_ERROR_CODES,
+  addAuthIntentToUrl,
+  buildAuthCallbackUrl,
+  classifyOAuthError,
+  getAuthIntentFromSearchParams,
+  getAuthRedirectPath,
+  getSafeRedirectPath,
+} from "./auth-intent";
+
+test("only allows same-origin relative redirect paths", () => {
+  assert.equal(getSafeRedirectPath("/subscription"), "/subscription");
+  assert.equal(getSafeRedirectPath("/subscription?plan=pro"), "/subscription?plan=pro");
+  assert.equal(getSafeRedirectPath("https://evil.example"), "/");
+  assert.equal(getSafeRedirectPath("//evil.example"), "/");
+  assert.equal(getSafeRedirectPath("/\\\\evil.example"), "/");
+});
+
+test("serializes the selected plan and next path into the callback URL", () => {
+  const callbackUrl = new URL(buildAuthCallbackUrl("https://resumelm.ca", {
+    next: "/subscription",
+    plan: "pro",
+  }));
+
+  assert.equal(callbackUrl.pathname, "/auth/callback");
+  assert.equal(callbackUrl.searchParams.get("next"), "/subscription");
+  assert.equal(callbackUrl.searchParams.get("plan"), "pro");
+});
+
+test("preserves intent when building a retry URL and chooses a Pro fallback", () => {
+  const retryUrl = addAuthIntentToUrl(new URL("https://resumelm.ca/auth/login"), {
+    next: "/subscription",
+    plan: "pro",
+  });
+
+  assert.equal(retryUrl.search, "?next=%2Fsubscription&plan=pro");
+  assert.deepEqual(
+    getAuthIntentFromSearchParams(retryUrl.searchParams),
+    { next: "/subscription", plan: "pro" },
+  );
+  assert.equal(getAuthRedirectPath({ plan: "pro" }), "/subscription");
+});
+
+test("classifies provider, state, and exchange failures separately", () => {
+  assert.equal(
+    classifyOAuthError({ providerError: "access_denied" }),
+    AUTH_ERROR_CODES.oauthProviderDenied,
+  );
+  assert.equal(
+    classifyOAuthError({ message: "State has already been used" }),
+    AUTH_ERROR_CODES.oauthStateMismatch,
+  );
+  assert.equal(
+    classifyOAuthError({ message: "invalid authorization code" }),
+    AUTH_ERROR_CODES.oauthExchangeFailed,
+  );
+});

--- a/src/lib/auth-intent.ts
+++ b/src/lib/auth-intent.ts
@@ -1,0 +1,125 @@
+export type AuthPlan = "free" | "pro";
+
+export interface AuthIntent {
+  next?: string;
+  plan?: AuthPlan;
+}
+
+export const AUTH_ERROR_CODES = {
+  emailConfirmation: "email_confirmation",
+  oauthMissingCode: "oauth_missing_code",
+  oauthProviderDenied: "oauth_provider_denied",
+  oauthProviderError: "oauth_provider_error",
+  oauthStateMismatch: "oauth_state_mismatch",
+  oauthExchangeFailed: "oauth_exchange_failed",
+  oauthStartFailed: "oauth_start_failed",
+} as const;
+
+export type AuthErrorCode = (typeof AUTH_ERROR_CODES)[keyof typeof AUTH_ERROR_CODES];
+
+export function getSafeRedirectPath(path: string | null | undefined, fallback = "/"): string {
+  if (
+    !path ||
+    !path.startsWith("/") ||
+    path.startsWith("//") ||
+    path.includes("\\") ||
+    /[\u0000-\u001f\u007f]/.test(path)
+  ) {
+    return fallback;
+  }
+
+  try {
+    const resolvedUrl = new URL(path, "https://resumelm.invalid");
+    if (resolvedUrl.origin !== "https://resumelm.invalid") {
+      return fallback;
+    }
+  } catch {
+    return fallback;
+  }
+
+  return path;
+}
+
+export function parseAuthPlan(plan: string | null | undefined): AuthPlan | undefined {
+  return plan === "free" || plan === "pro" ? plan : undefined;
+}
+
+export function normalizeAuthIntent(intent?: AuthIntent | null): AuthIntent {
+  const next = intent?.next ? getSafeRedirectPath(intent.next, "") || undefined : undefined;
+  const plan = parseAuthPlan(intent?.plan);
+
+  return {
+    ...(next ? { next } : {}),
+    ...(plan ? { plan } : {}),
+  };
+}
+
+export function getAuthIntentFromParams(params: {
+  next?: string | null;
+  plan?: string | null;
+}): AuthIntent {
+  return normalizeAuthIntent({
+    next: params.next ?? undefined,
+    plan: parseAuthPlan(params.plan),
+  });
+}
+
+export function getAuthIntentFromSearchParams(searchParams: URLSearchParams): AuthIntent {
+  return getAuthIntentFromParams({
+    next: searchParams.get("next"),
+    plan: searchParams.get("plan"),
+  });
+}
+
+export function addAuthIntentToUrl(url: URL, intent?: AuthIntent | null): URL {
+  const normalized = normalizeAuthIntent(intent);
+
+  if (normalized.next) {
+    url.searchParams.set("next", normalized.next);
+  }
+  if (normalized.plan) {
+    url.searchParams.set("plan", normalized.plan);
+  }
+
+  return url;
+}
+
+export function buildAuthCallbackUrl(siteUrl: string, intent?: AuthIntent | null): string {
+  return addAuthIntentToUrl(new URL("/auth/callback", siteUrl), intent).toString();
+}
+
+export function getAuthRedirectPath(intent?: AuthIntent | null, fallback = "/"): string {
+  const normalized = normalizeAuthIntent(intent);
+
+  if (normalized.next) {
+    return normalized.next;
+  }
+
+  if (normalized.plan === "pro") {
+    return "/subscription";
+  }
+
+  return fallback;
+}
+
+export function classifyOAuthError(params: {
+  providerError?: string | null;
+  message?: string | null;
+}): AuthErrorCode {
+  const providerError = params.providerError?.toLowerCase();
+  const message = params.message?.toLowerCase() ?? "";
+
+  if (providerError === "access_denied") {
+    return AUTH_ERROR_CODES.oauthProviderDenied;
+  }
+
+  if (message.includes("state") || message.includes("flow_state")) {
+    return AUTH_ERROR_CODES.oauthStateMismatch;
+  }
+
+  if (providerError) {
+    return AUTH_ERROR_CODES.oauthProviderError;
+  }
+
+  return AUTH_ERROR_CODES.oauthExchangeFailed;
+}

--- a/src/utils/supabase/middleware.ts
+++ b/src/utils/supabase/middleware.ts
@@ -63,19 +63,6 @@ export async function updateSession(request: NextRequest) {
   // Debug logging
   console.log('👤 User authenticated:', !!user, 'user_id:', user?.id)
 
-  // Create a new headers object with the existing headers
-  // Given an incoming request...
-  const requestHeaders = new Headers(request.headers)
-
-
-  // Create new response with enriched headers
-  supabaseResponse = NextResponse.next({
-    request: {
-      ...request,
-      headers: requestHeaders,
-    },
-  })
-
   supabaseResponse.cookies.set('show-banner', 'false')
 
   // Check if user is authenticated and redirect if needed
@@ -95,7 +82,9 @@ export async function updateSession(request: NextRequest) {
     console.log('🚫 Redirecting unauthenticated user to landing page')
     const url = request.nextUrl.clone()
     url.pathname = '/'
-    return NextResponse.redirect(url)
+    const redirectResponse = NextResponse.redirect(url)
+    supabaseResponse.cookies.getAll().forEach((cookie) => redirectResponse.cookies.set(cookie))
+    return redirectResponse
   }
 
   // Check if route requires subscription
@@ -131,7 +120,9 @@ export async function updateSession(request: NextRequest) {
       console.log('🚫 User subscription access expired or invalid, redirecting to home')
       const url = request.nextUrl.clone()
       url.pathname = '/home'
-      return NextResponse.redirect(url)
+      const redirectResponse = NextResponse.redirect(url)
+      supabaseResponse.cookies.getAll().forEach((cookie) => redirectResponse.cookies.set(cookie))
+      return redirectResponse
     }
   }
 


### PR DESCRIPTION
## Summary
- carry the selected plan and `next` path through the Supabase/Google callback
- remove forced Google consent/offline access and classify callback failures
- preserve refreshed Supabase cookies in callback and middleware redirects
- keep email sign-in and retry flows on the requested destination

## Verification
- `npm test`
- `npm run typecheck`
- `npm run lint`
- `npm run build` (with non-production placeholder environment values)
- local callback checks for missing-code, provider-denied, and unsafe redirect cases
