### PR TITLE
Preserve Stripe payment recovery state

### DIFF
--- a/src/app/(dashboard)/settings/page.tsx
+++ b/src/app/(dashboard)/settings/page.tsx
@@ -14,7 +14,7 @@ export default async function SettingsPage() {
   const { data: subscription } = user
     ? await supabase
         .from('subscriptions')
-        .select('subscription_plan, subscription_status, current_period_end, trial_end, stripe_subscription_id')
+        .select('subscription_plan, subscription_status, current_period_end, trial_end, stripe_subscription_id, payment_failure_count, last_payment_failed_at, next_payment_attempt_at')
         .eq('user_id', user.id)
         .maybeSingle()
     : { data: null };

--- a/src/app/(dashboard)/subscription/page.tsx
+++ b/src/app/(dashboard)/subscription/page.tsx
@@ -12,6 +12,9 @@ interface Profile {
   trial_end: string | null;
   stripe_customer_id: string | null;
   stripe_subscription_id: string | null;
+  payment_failure_count?: number | null;
+  last_payment_failed_at?: string | null;
+  next_payment_attempt_at?: string | null;
 }
 
 export default async function PlansPage() {

--- a/src/app/api/webhooks/stripe/route.ts
+++ b/src/app/api/webhooks/stripe/route.ts
@@ -7,6 +7,8 @@ import { createServiceClient } from '@/utils/supabase/server'
 import { AnalyticsEvents } from '@/lib/analytics/events'
 import { captureServerAnalyticsEvent } from '@/lib/analytics/server'
 import {
+  getPaymentFailureRecoveryFields,
+  getPaymentRecoveryClearedFields,
   getInvoiceSubscriptionId,
   isFirstPaidInvoice,
   shouldCaptureTrialStarted,
@@ -23,6 +25,7 @@ const relevantEvents = new Set([
   'checkout.session.completed',
   'invoice.paid',
   'invoice.payment_failed',
+  'invoice.updated',
   'customer.subscription.created',
   'customer.subscription.updated',
   'customer.subscription.deleted',
@@ -235,11 +238,25 @@ async function captureInvoicePaymentFailedEvent(input: {
   eventType: string;
   invoice: Stripe.Invoice;
   subscriptionData: Partial<Subscription>;
+  supabase: ServiceSupabaseClient;
 }) {
   if (input.eventType !== 'invoice.payment_failed') return;
 
   const userId = input.subscriptionData.user_id;
   if (!userId) return;
+
+  const recoveryFields = getPaymentFailureRecoveryFields(input.invoice);
+  const { error: recoveryUpdateError } = await input.supabase
+    .from('subscriptions')
+    .update({
+      ...recoveryFields,
+      updated_at: new Date().toISOString(),
+    })
+    .eq('user_id', userId);
+
+  if (recoveryUpdateError) {
+    throw recoveryUpdateError;
+  }
 
   await captureServerAnalyticsEvent({
     distinctId: userId,
@@ -253,11 +270,46 @@ async function captureInvoicePaymentFailedEvent(input: {
       currency: input.invoice.currency,
       billing_reason: input.invoice.billing_reason,
       attempt_count: input.invoice.attempt_count,
-      next_payment_attempt: input.invoice.next_payment_attempt
-        ? new Date(input.invoice.next_payment_attempt * 1000).toISOString()
-        : null,
+      next_payment_attempt: recoveryFields.next_payment_attempt_at,
     },
   });
+}
+
+async function clearInvoicePaymentRecovery(
+  supabase: ServiceSupabaseClient,
+  subscriptionData: Partial<Subscription>
+) {
+  const userId = subscriptionData.user_id;
+  if (!userId) return;
+
+  const { error } = await supabase
+    .from('subscriptions')
+    .update({
+      ...getPaymentRecoveryClearedFields(),
+      updated_at: new Date().toISOString(),
+    })
+    .eq('user_id', userId);
+
+  if (error) throw error;
+}
+
+async function updateNextPaymentAttempt(
+  supabase: ServiceSupabaseClient,
+  invoice: Stripe.Invoice,
+  subscriptionData: Partial<Subscription>
+) {
+  const userId = subscriptionData.user_id;
+  if (!userId || !invoice.next_payment_attempt) return;
+
+  const { error } = await supabase
+    .from('subscriptions')
+    .update({
+      next_payment_attempt_at: new Date(invoice.next_payment_attempt * 1000).toISOString(),
+      updated_at: new Date().toISOString(),
+    })
+    .eq('user_id', userId);
+
+  if (error) throw error;
 }
 
 async function captureFirstInvoicePaidEvent(input: {
@@ -420,6 +472,7 @@ export async function POST(req: Request) {
             getCustomerId(invoice.customer as string | Stripe.Customer | Stripe.DeletedCustomer | null),
             subscriptionId
           );
+          await clearInvoicePaymentRecovery(supabase, subscriptionData);
           await captureFirstInvoicePaidEvent({
             invoice,
             subscriptionId,
@@ -442,7 +495,29 @@ export async function POST(req: Request) {
             eventType: event.type,
             invoice,
             subscriptionData,
+            supabase,
           });
+        }
+        break;
+      }
+
+      case 'invoice.updated': {
+        const invoice = event.data.object as InvoiceWithSubscription;
+        const subscriptionId = getInvoiceSubscriptionId(invoice);
+
+        // Stripe may publish the next retry time on invoice.updated rather
+        // than invoice.payment_failed when Automations are enabled.
+        if (
+          subscriptionId &&
+          invoice.status === 'open' &&
+          (invoice.attempt_count ?? 0) > 0 &&
+          invoice.next_payment_attempt
+        ) {
+          const subscriptionData = await handleSubscriptionChange(
+            getCustomerId(invoice.customer as string | Stripe.Customer | Stripe.DeletedCustomer | null),
+            subscriptionId
+          );
+          await updateNextPaymentAttempt(supabase, invoice, subscriptionData);
         }
         break;
       }

--- a/src/components/pricing/optimized-subscription-page.tsx
+++ b/src/components/pricing/optimized-subscription-page.tsx
@@ -13,7 +13,8 @@ import {
   Crown,
   Star,
   Zap,
-  ArrowRight
+  ArrowRight,
+  AlertCircle,
 } from 'lucide-react';
 import { createPortalSession } from '@/app/(dashboard)/subscription/stripe-session';
 import { motion } from 'framer-motion';
@@ -61,11 +62,19 @@ export function OptimizedSubscriptionPage({ initialProfile }: OptimizedSubscript
   const subscriptionAccessState = getSubscriptionAccessState(initialProfile);
   const {
     hasProAccess,
+    isPastDue,
     isCanceling,
     isExpiredProAccess,
     daysRemaining,
     currentPeriodEndLabel,
   } = subscriptionAccessState;
+  const paymentFailureCount = initialProfile?.payment_failure_count ?? 0;
+  const nextPaymentAttemptLabel = initialProfile?.next_payment_attempt_at
+    ? new Date(initialProfile.next_payment_attempt_at).toLocaleString(undefined, {
+        dateStyle: 'medium',
+        timeStyle: 'short',
+      })
+    : null;
 
   const handleUpgrade = async () => {
     if (hasProAccess) {
@@ -141,6 +150,21 @@ export function OptimizedSubscriptionPage({ initialProfile }: OptimizedSubscript
                   : "Your previous Pro access has ended. Upgrade to unlock premium features again."}
               </p>
             </>
+          ) : isPastDue ? (
+            <>
+              <div className="flex items-center justify-center mb-4">
+                <AlertCircle className="h-8 w-8 text-amber-500 mr-3" />
+                <Badge variant="outline" className="text-amber-700 border-amber-300 bg-amber-50">
+                  Payment needs attention
+                </Badge>
+              </div>
+              <h1 className="text-4xl font-bold text-gray-900 mb-4">
+                Keep your Pro access active
+              </h1>
+              <p className="text-xl text-gray-600 max-w-2xl mx-auto">
+                We couldn&apos;t collect your latest payment. Stripe will retry automatically, and you can update your payment method now.
+              </p>
+            </>
           ) : hasProAccess ? (
             <>
               <div className="flex items-center justify-center mb-4">
@@ -173,6 +197,27 @@ export function OptimizedSubscriptionPage({ initialProfile }: OptimizedSubscript
             </>
           )}
         </motion.div>
+
+        {isPastDue && (
+          <motion.div
+            initial={{ opacity: 0, y: 10 }}
+            animate={{ opacity: 1, y: 0 }}
+            className="mb-8 rounded-xl border border-amber-200 bg-amber-50 p-5 text-amber-950"
+            role="alert"
+          >
+            <div className="flex items-start gap-3">
+              <AlertCircle className="mt-0.5 h-5 w-5 flex-shrink-0 text-amber-600" />
+              <div className="flex-1">
+                <h2 className="font-semibold">Payment recovery is in progress</h2>
+                <p className="mt-1 text-sm text-amber-800">
+                  Your Pro features remain available while Stripe retries the payment. Update your payment method to avoid an interruption.
+                  {paymentFailureCount > 0 && ` Attempt ${paymentFailureCount} has failed.`}
+                  {nextPaymentAttemptLabel && ` The next retry is scheduled for ${nextPaymentAttemptLabel}.`}
+                </p>
+              </div>
+            </div>
+          </motion.div>
+        )}
 
         {/* Social Proof Bar */}
         <motion.div 
@@ -353,7 +398,7 @@ export function OptimizedSubscriptionPage({ initialProfile }: OptimizedSubscript
                     <span>Processing...</span>
                   </div>
                 ) : hasProAccess ? (
-                  "Manage Subscription"
+                  isPastDue ? "Fix payment method" : "Manage Subscription"
                 ) : (
                   <div className="flex items-center justify-center space-x-2">
                     <span>Start Landing More Interviews</span>

--- a/src/components/settings/subscription-section.tsx
+++ b/src/components/settings/subscription-section.tsx
@@ -4,7 +4,7 @@ import { useState } from 'react';
 import { useRouter } from 'next/navigation';
 import { Button } from "@/components/ui/button"
 import { Badge } from "@/components/ui/badge"
-import { Sparkles, Star, Clock, Zap, ArrowRight, Crown, Shield, Check, Users, TrendingUp } from "lucide-react"
+import { Sparkles, Star, Clock, Zap, ArrowRight, Crown, Shield, Check, Users, TrendingUp, AlertCircle } from "lucide-react"
 import { cn } from '@/lib/utils';
 import { createPortalSession } from '@/app/(dashboard)/subscription/stripe-session';
 import { getSubscriptionAccessState, type SubscriptionSnapshot } from '@/lib/subscription-access';
@@ -20,6 +20,7 @@ export function SubscriptionSection({ initialProfile }: SubscriptionSectionProps
   const subscriptionAccessState = getSubscriptionAccessState(initialProfile);
   const {
     hasProAccess,
+    isPastDue,
     isCanceling,
     isExpiredProAccess,
     isTrialing,
@@ -28,6 +29,13 @@ export function SubscriptionSection({ initialProfile }: SubscriptionSectionProps
     trialDaysRemaining,
     trialEndLabel,
   } = subscriptionAccessState;
+  const paymentFailureCount = initialProfile?.payment_failure_count ?? 0;
+  const nextPaymentAttemptLabel = initialProfile?.next_payment_attempt_at
+    ? new Date(initialProfile.next_payment_attempt_at).toLocaleString(undefined, {
+        dateStyle: 'medium',
+        timeStyle: 'short',
+      })
+    : null;
 
   const handleSubscriptionAction = async () => {
     if (!hasProAccess) {
@@ -98,6 +106,21 @@ export function SubscriptionSection({ initialProfile }: SubscriptionSectionProps
                 : "Your previous Pro access has ended. Upgrade to regain premium features."}
             </p>
           </>
+        ) : isPastDue ? (
+          <>
+            <div className="flex items-center justify-center mb-2">
+              <AlertCircle className="h-6 w-6 text-amber-500 mr-2" />
+              <Badge variant="outline" className="text-amber-700 border-amber-300 bg-amber-50">
+                Payment needs attention
+              </Badge>
+            </div>
+            <h2 className="text-2xl font-bold text-gray-900">
+              Keep your Pro access active
+            </h2>
+            <p className="text-gray-600 max-w-lg mx-auto">
+              We couldn&apos;t collect your latest payment. Stripe will retry automatically; update your payment method to avoid an interruption.
+            </p>
+          </>
         ) : isTrialing ? (
           <>
             <div className="flex items-center justify-center mb-2">
@@ -144,6 +167,22 @@ export function SubscriptionSection({ initialProfile }: SubscriptionSectionProps
           </>
         )}
       </div>
+
+      {isPastDue && (
+        <div className="rounded-xl border border-amber-200 bg-amber-50 p-4 text-amber-950" role="alert">
+          <div className="flex items-start gap-3">
+            <AlertCircle className="mt-0.5 h-5 w-5 flex-shrink-0 text-amber-600" />
+            <div>
+              <h3 className="font-semibold">Payment recovery is in progress</h3>
+              <p className="mt-1 text-sm text-amber-800">
+                Your Pro features remain available while Stripe retries the payment.
+                {paymentFailureCount > 0 && ` Attempt ${paymentFailureCount} has failed.`}
+                {nextPaymentAttemptLabel && ` The next retry is scheduled for ${nextPaymentAttemptLabel}.`}
+              </p>
+            </div>
+          </div>
+        </div>
+      )}
 
       {/* Social Proof */}
       <div className="flex items-center justify-center text-sm text-gray-600">
@@ -286,7 +325,7 @@ export function SubscriptionSection({ initialProfile }: SubscriptionSectionProps
                   <span>Loading...</span>
                 </div>
               ) : hasProAccess ? (
-                isTrialing ? "Manage trial / billing" : "Manage Subscription"
+                isPastDue ? "Fix payment method" : isTrialing ? "Manage trial / billing" : "Manage Subscription"
               ) : (
                 <div className="flex items-center justify-center space-x-2">
                   <span>Upgrade to Pro</span>

--- a/src/lib/stripe/billing-events.test.ts
+++ b/src/lib/stripe/billing-events.test.ts
@@ -2,6 +2,8 @@ import assert from "node:assert/strict";
 import { describe, it } from "node:test";
 
 import {
+  getPaymentFailureRecoveryFields,
+  getPaymentRecoveryClearedFields,
   getInvoiceSubscriptionId,
   isFirstPaidInvoice,
   shouldCaptureTrialStarted,
@@ -111,5 +113,28 @@ describe("Stripe billing lifecycle event classification", () => {
       ),
       "sub_current"
     );
+  });
+
+  it("records the Stripe retry attempt and next scheduled attempt", () => {
+    assert.deepEqual(
+      getPaymentFailureRecoveryFields({
+        attempt_count: 2,
+        created: 1770000000,
+        next_payment_attempt: 1770086400,
+      }),
+      {
+        payment_failure_count: 2,
+        last_payment_failed_at: "2026-02-02T02:40:00.000Z",
+        next_payment_attempt_at: "2026-02-03T02:40:00.000Z",
+      },
+    );
+  });
+
+  it("clears recovery metadata after a paid invoice", () => {
+    assert.deepEqual(getPaymentRecoveryClearedFields(), {
+      payment_failure_count: 0,
+      last_payment_failed_at: null,
+      next_payment_attempt_at: null,
+    });
   });
 });

--- a/src/lib/stripe/billing-events.ts
+++ b/src/lib/stripe/billing-events.ts
@@ -77,3 +77,30 @@ export function isFirstPaidInvoice(input: {
       candidate.amount_paid > 0
   );
 }
+
+export interface PaymentRecoveryFields {
+  payment_failure_count: number;
+  last_payment_failed_at: string | null;
+  next_payment_attempt_at: string | null;
+}
+
+export function getPaymentFailureRecoveryFields(input: Pick<
+  Stripe.Invoice,
+  "attempt_count" | "created" | "next_payment_attempt"
+>): PaymentRecoveryFields {
+  return {
+    payment_failure_count: Math.max(1, input.attempt_count ?? 1),
+    last_payment_failed_at: new Date(input.created * 1000).toISOString(),
+    next_payment_attempt_at: input.next_payment_attempt
+      ? new Date(input.next_payment_attempt * 1000).toISOString()
+      : null,
+  };
+}
+
+export function getPaymentRecoveryClearedFields(): PaymentRecoveryFields {
+  return {
+    payment_failure_count: 0,
+    last_payment_failed_at: null,
+    next_payment_attempt_at: null,
+  };
+}

--- a/src/lib/stripe/subscription-sync.test.ts
+++ b/src/lib/stripe/subscription-sync.test.ts
@@ -43,6 +43,23 @@ describe("mapStripeSubscriptionToAppSubscription", () => {
     assert.equal(result.subscription_status, "active");
   });
 
+  it("preserves a past-due Pro subscription while Stripe retries payment", () => {
+    const result = mapStripeSubscriptionToAppSubscription({
+      userId: "user_1",
+      customerId: "cus_1",
+      subscriptionId: "sub_1",
+      priceId: proPriceId,
+      stripeStatus: "past_due",
+      currentPeriodEnd: new Date("2026-06-01T00:00:00Z"),
+      trialEnd: null,
+      cancelAtPeriodEnd: false,
+      proPriceId,
+    });
+
+    assert.equal(result.subscription_plan, "pro");
+    assert.equal(result.subscription_status, "past_due");
+  });
+
   it("maps non-Pro prices to free even when Stripe is active", () => {
     const result = mapStripeSubscriptionToAppSubscription({
       userId: "user_1",
@@ -146,6 +163,28 @@ describe("shouldSkipStaleInactiveSubscriptionUpdate", () => {
     });
 
     assert.equal(shouldSkip, false);
+  });
+
+  it("protects a current past-due recovery cycle from stale inactive events", () => {
+    const shouldSkip = shouldSkipStaleInactiveSubscriptionUpdate({
+      now,
+      currentSubscription: {
+        stripe_subscription_id: "sub_current",
+        subscription_plan: "pro",
+        subscription_status: "past_due",
+        current_period_end: "2026-06-01T00:00:00.000Z",
+        trial_end: null,
+      },
+      incomingSubscription: {
+        stripe_subscription_id: "sub_old",
+        subscription_plan: "free",
+        subscription_status: "canceled",
+        current_period_end: "2026-05-01T00:00:00.000Z",
+        trial_end: null,
+      },
+    });
+
+    assert.equal(shouldSkip, true);
   });
 
   it("does not skip stale updates when the current entitlement has expired", () => {

--- a/src/lib/stripe/subscription-sync.ts
+++ b/src/lib/stripe/subscription-sync.ts
@@ -36,15 +36,19 @@ export function mapStripeSubscriptionToAppSubscription(
   const isKnownProPrice = input.priceId === input.proPriceId;
   const isActiveLike =
     input.stripeStatus === "active" || input.stripeStatus === "trialing";
-  const shouldHaveProPlan = isKnownProPrice && isActiveLike;
+  const isPastDue = input.stripeStatus === "past_due";
+  const shouldHaveProPlan = isKnownProPrice && (isActiveLike || isPastDue);
 
   return {
     user_id: input.userId,
     stripe_customer_id: input.customerId,
     stripe_subscription_id: input.subscriptionId,
     subscription_plan: shouldHaveProPlan ? "pro" : "free",
-    subscription_status:
-      shouldHaveProPlan && !input.cancelAtPeriodEnd ? "active" : "canceled",
+    subscription_status: isPastDue
+      ? "past_due"
+      : shouldHaveProPlan && !input.cancelAtPeriodEnd
+        ? "active"
+        : "canceled",
     current_period_end: input.currentPeriodEnd?.toISOString() ?? null,
     trial_end: input.trialEnd?.toISOString() ?? null,
     updated_at: new Date().toISOString(),
@@ -87,12 +91,13 @@ export function shouldSkipStaleInactiveSubscriptionUpdate(input: {
     return false;
   }
 
-  const currentIsActivePro =
+  const currentHasRecoverableProAccess =
     currentSubscription.subscription_plan === "pro" &&
-    currentSubscription.subscription_status === "active" &&
+    (currentSubscription.subscription_status === "active" ||
+      currentSubscription.subscription_status === "past_due") &&
     hasFutureEntitlementDate(currentSubscription, now);
 
-  if (!currentIsActivePro) {
+  if (!currentHasRecoverableProAccess) {
     return false;
   }
 

--- a/src/lib/subscription-access.test.ts
+++ b/src/lib/subscription-access.test.ts
@@ -55,4 +55,38 @@ describe("getSubscriptionAccessState", () => {
     assert.equal(result.effectivePlan, "pro");
     assert.equal(result.isCanceling, true);
   });
+
+  it("keeps Pro access during Stripe's past-due retry window", () => {
+    const result = getSubscriptionAccessState(
+      {
+        subscription_plan: "pro",
+        subscription_status: "past_due",
+        stripe_subscription_id: "sub_1",
+        current_period_end: "2026-06-01T00:00:00.000Z",
+        trial_end: null,
+      },
+      now
+    );
+
+    assert.equal(result.isPastDue, true);
+    assert.equal(result.hasProAccess, true);
+    assert.equal(result.effectivePlan, "pro");
+  });
+
+  it("does not keep expired past-due access open forever", () => {
+    const result = getSubscriptionAccessState(
+      {
+        subscription_plan: "pro",
+        subscription_status: "past_due",
+        stripe_subscription_id: "sub_1",
+        current_period_end: "2026-05-01T00:00:00.000Z",
+        trial_end: null,
+      },
+      now
+    );
+
+    assert.equal(result.hasProAccess, false);
+    assert.equal(result.isExpiredProAccess, true);
+    assert.equal(result.effectivePlan, "free");
+  });
 });

--- a/src/lib/subscription-access.ts
+++ b/src/lib/subscription-access.ts
@@ -4,10 +4,14 @@ export interface SubscriptionSnapshot {
   current_period_end?: string | null;
   trial_end?: string | null;
   stripe_subscription_id?: string | null;
+  payment_failure_count?: number | null;
+  last_payment_failed_at?: string | null;
+  next_payment_attempt_at?: string | null;
 }
 
 export interface SubscriptionAccessState {
   isTrialing: boolean;
+  isPastDue: boolean;
   isWithinAccessWindow: boolean;
   hasStripeSubscription: boolean;
   hasProAccess: boolean;
@@ -59,25 +63,31 @@ export function getSubscriptionAccessState(
   const trialEnd = parseDate(subscription?.trial_end);
 
   const isTrialing = isFutureDate(trialEnd, now);
+  const isPastDue = status === "past_due";
   const hasStripeSubscription = Boolean(subscription?.stripe_subscription_id);
   const isWithinAccessWindow = isFutureDate(currentPeriodEnd, now);
 
   const hasManualProAccess = plan === "pro" && status === "active";
   const hasTrialingProAccess = plan === "pro" && isTrialing;
+  const hasPastDueProAccess = plan === "pro" && isPastDue && isWithinAccessWindow;
   const hasCancelingProAccess = plan === "pro" && status === "canceled" && isWithinAccessWindow;
 
   const hasProAccess =
-    hasManualProAccess || hasTrialingProAccess || hasCancelingProAccess;
+    hasManualProAccess || hasTrialingProAccess || hasPastDueProAccess || hasCancelingProAccess;
 
   const hadPaidAccess = plan === "pro";
   const isCanceling = status === "canceled" && isWithinAccessWindow;
-  const isExpiredProAccess = status === "canceled" && !isWithinAccessWindow && hadPaidAccess;
+  const isExpiredProAccess =
+    (status === "canceled" || status === "past_due") &&
+    !isWithinAccessWindow &&
+    hadPaidAccess;
 
   const hasSubscriptionRecord = Boolean(subscription);
   const effectivePlan = hasSubscriptionRecord ? (hasProAccess ? "pro" : "free") : "";
 
   return {
     isTrialing,
+    isPastDue,
     isWithinAccessWindow,
     hasStripeSubscription,
     hasProAccess,

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -172,9 +172,12 @@ export interface Subscription {
   stripe_customer_id: string | null;
   stripe_subscription_id: string | null;
   subscription_plan: 'free' | 'pro';
-  subscription_status: 'active' | 'canceled';
+  subscription_status: 'active' | 'past_due' | 'unpaid' | 'incomplete' | 'paused' | 'canceled' | null;
   current_period_end: string | null;
   trial_end: string | null;
+  payment_failure_count?: number;
+  last_payment_failed_at?: string | null;
+  next_payment_attempt_at?: string | null;
   created_at: string;
   updated_at: string;
 }

--- a/src/utils/actions/stripe/actions.ts
+++ b/src/utils/actions/stripe/actions.ts
@@ -323,7 +323,10 @@ export async function getSubscriptionStatus() {
       current_period_end,
       trial_end,
       stripe_customer_id,
-      stripe_subscription_id
+      stripe_subscription_id,
+      payment_failure_count,
+      last_payment_failed_at,
+      next_payment_attempt_at
     `)
     .eq('user_id', user.id)
     .single();
@@ -338,7 +341,10 @@ export async function getSubscriptionStatus() {
         current_period_end: null,
         trial_end: null,
         stripe_customer_id: null,
-        stripe_subscription_id: null
+        stripe_subscription_id: null,
+        payment_failure_count: 0,
+        last_payment_failed_at: null,
+        next_payment_attempt_at: null
       };
     }
     throw new Error('Failed to fetch subscription status');

--- a/supabase/migrations/20260731060000_payment_recovery_fields.sql
+++ b/supabase/migrations/20260731060000_payment_recovery_fields.sql
@@ -1,0 +1,20 @@
+ALTER TABLE public.subscriptions
+  ADD COLUMN IF NOT EXISTS payment_failure_count integer NOT NULL DEFAULT 0,
+  ADD COLUMN IF NOT EXISTS last_payment_failed_at timestamp with time zone,
+  ADD COLUMN IF NOT EXISTS next_payment_attempt_at timestamp with time zone;
+
+ALTER TABLE public.subscriptions
+  DROP CONSTRAINT IF EXISTS subscriptions_payment_failure_count_nonnegative;
+
+ALTER TABLE public.subscriptions
+  ADD CONSTRAINT subscriptions_payment_failure_count_nonnegative
+  CHECK (payment_failure_count >= 0);
+
+COMMENT ON COLUMN public.subscriptions.payment_failure_count IS
+  'Number of attempts recorded for the current failed-invoice recovery cycle.';
+
+COMMENT ON COLUMN public.subscriptions.last_payment_failed_at IS
+  'Timestamp of the most recent failed subscription invoice payment.';
+
+COMMENT ON COLUMN public.subscriptions.next_payment_attempt_at IS
+  'Stripe scheduled retry time, when Stripe provides one.';


### PR DESCRIPTION
## What changed

- Preserve Pro entitlements while Stripe marks a subscription `past_due` and retries payment.
- Persist failed-invoice attempt count, failure timestamp, and next retry timestamp in Supabase.
- Clear recovery metadata on `invoice.paid` and handle retry timestamps delivered by `invoice.updated`.
- Keep Stripe recovery state visible in the subscription/settings screens with a direct portal path to update payment methods.
- Configure the live Stripe account to leave subscriptions `past_due` after retries and enable failed-card recovery emails.

## Why

The webhook acknowledged `invoice.payment_failed` but only emitted analytics. The subscription sync then mapped Stripe `past_due` to `free/canceled`, removing the customer’s entitlement and hiding the billing problem. This repair keeps access during the configured retry window, records the recovery state, and gives customers a clear way to fix payment.

## Verification

- `npm test` (71 passing)
- `npm run typecheck`
- `npm run lint`
- `npm run build` with build-time environment placeholders
- Live Supabase migration applied and schema/counts verified
- Live Stripe Smart Retries and recovery-email settings verified
