### PR TITLE
fix: allow past-due subscription recovery

### DIFF
--- a/docker/supabase/volumes/db/init/01-app-schema.sql
+++ b/docker/supabase/volumes/db/init/01-app-schema.sql
@@ -38,7 +38,9 @@ CREATE TABLE IF NOT EXISTS public.subscriptions (
     (
       (subscription_status IS NULL)
       OR (
-        subscription_status = ANY (ARRAY['active'::text, 'canceled'::text])
+        subscription_status = ANY (
+          ARRAY['active'::text, 'past_due'::text, 'canceled'::text]
+        )
       )
     )
   )

--- a/schema.sql
+++ b/schema.sql
@@ -39,7 +39,9 @@ CREATE TABLE IF NOT EXISTS public.subscriptions (
     (
       (subscription_status IS NULL)
       OR (
-        subscription_status = ANY (ARRAY['active'::text, 'canceled'::text])
+        subscription_status = ANY (
+          ARRAY['active'::text, 'past_due'::text, 'canceled'::text]
+        )
       )
     )
   )

--- a/supabase/migrations/20260731073000_allow_past_due_subscription_status.sql
+++ b/supabase/migrations/20260731073000_allow_past_due_subscription_status.sql
@@ -1,0 +1,13 @@
+-- Preserve a Pro entitlement while Stripe is retrying a failed invoice.
+-- The application maps Stripe's past_due state directly into this column.
+
+ALTER TABLE public.subscriptions
+  DROP CONSTRAINT IF EXISTS subscriptions_subscription_status_check;
+
+ALTER TABLE public.subscriptions
+  ADD CONSTRAINT subscriptions_subscription_status_check CHECK (
+    subscription_status IS NULL
+    OR subscription_status = ANY (
+      ARRAY['active'::text, 'past_due'::text, 'canceled'::text]
+    )
+  );


### PR DESCRIPTION
## Summary
- allow `past_due` in the subscriptions status check constraint
- keep the canonical schema and local database bootstrap aligned
- unblock Stripe `invoice.payment_failed` recovery writes and entitlement preservation

## Root cause
The application now maps a Pro Stripe subscription in `past_due` to `subscription_status = 'past_due'`, but the production database constraint still allowed only `active` and `canceled`. A replayed live `invoice.payment_failed` event reached the new handler, then failed on that constraint before recording recovery metadata.

## Verification
- `npm test -- --runInBand` (71 passing)
- `npm run typecheck`
- `npm run lint`
- `git diff --check`
- applied migration to production Supabase and verified the constraint
- replayed live Stripe event `evt_1TzHvXCv6RlaQFiMK1rwVseP`; event is now processed and the linked subscription is `pro` / `past_due` with `payment_failure_count = 2` and a scheduled retry timestamp
