### PR TITLE
fix: restore signup intent and public trust

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,35 +4,29 @@
 
 ![ResumeLM Logo](public/og.webp)
 
-**🚀 The AI-Powered Resume Builder That Gets You Hired**
+**🚀 An open-source AI resume builder for tech job applications**
 
-[![Live Demo](https://img.shields.io/badge/🌐_Live_Demo-resumelm.com-blue?style=for-the-badge)](https://resumelm.com)
+[![Live Demo](https://img.shields.io/badge/🌐_Live_Demo-resumelm.ca-blue?style=for-the-badge)](https://resumelm.ca)
 [![GitHub Stars](https://img.shields.io/github/stars/olyaiy/resume-lm?style=for-the-badge)](https://github.com/olyaiy/resume-lm/stargazers)
 [![License: AGPL v3](https://img.shields.io/badge/License-AGPL_v3-blue.svg?style=for-the-badge)](https://www.gnu.org/licenses/agpl-3.0)
 [![Next.js](https://img.shields.io/badge/Next.js-15-black?style=for-the-badge&logo=next.js)](https://nextjs.org/)
 
 </div>
 
-## 📊 Proven Results That Matter
+## 📊 Product facts
 
-<div align="center">
-
-| 📈 **500+ Resumes Created** | 🎯 **89% Interview Rate** | ⭐ **4.9/5 User Rating** | ⏱️ **15 min Setup Time** |
-|:---------------------------:|:-------------------------:|:------------------------:|:-------------------------:|
-| Professional resumes built | Higher interview success  | Excellent user satisfaction | Quick and easy setup |
-
-</div>
+ResumeLM is open source, self-hostable, and has a free plan that supports your own AI provider keys. Pro is $20/month and provides app-funded premium model access.
 
 ## 🎯 Why Choose ResumeLM?
 
-**ResumeLM** is a free, open-source AI resume builder that helps job seekers create professional, ATS-optimized resumes that increase interview chances by up to **3x**. Our intelligent platform combines cutting-edge AI technology with proven resume best practices to help you land your dream job.
+**ResumeLM** is an open-source AI resume builder that helps job seekers create professional, ATS-aware resumes and tailored versions for specific applications.
 
 ## ✨ Key Features & Screenshots
 
 ### 🤖 AI-Powered Resume Assistant
 ![AI Resume Assistant](public/SS%20Chat.png)
 
-**90% More Effective Bullet Points**
+**AI-assisted bullet editing**
 - Smart content suggestions based on your experience
 - Real-time feedback on your resume content
 - Industry-specific optimization for better results
@@ -48,7 +42,7 @@
 ### 📈 Resume Performance Scoring
 ![Resume Scoring](public/SS%20Score.png)
 
-**3x Higher Response Rates**
+**Resume performance feedback**
 - ATS compatibility scoring and analysis
 - Keyword optimization insights
 - Detailed improvement recommendations
@@ -65,9 +59,9 @@
 
 ## 🚀 Live Demo & Getting Started
 
-**[Try ResumeLM Now - 100% Free](https://resumelm.com)**
+**[Try ResumeLM](https://resumelm.ca)**
 
-No credit card required • No signup fees • Open source
+Free plan available • Pro is $20/month • A payment method is required for the optional trial
 
 ## 🛠️ Complete Tech Stack
 
@@ -197,7 +191,7 @@ cd ..
 pnpm dev
 ```
 
-**Login:** http://localhost:3000 with `admin@admin.com` / `Admin123` (Pro subscription auto-granted)
+**Login:** http://localhost:3000 and create a local account with credentials you control. Do not reuse example credentials in development or production.
 
 | Service | URL | Description |
 |---------|-----|-------------|
@@ -262,17 +256,10 @@ pnpm dev
 
 ## 📈 Performance & Analytics
 
-### Core Metrics
-- **Page Load Speed** - Under 2 seconds average
-- **Mobile Performance** - 95+ Lighthouse score
-- **SEO Optimization** - Structured data and meta tags
-- **Accessibility** - WCAG 2.1 AA compliant
-
-### User Success Stories
-- 89% of users report getting more interview calls
-- Average setup time reduced to just 15 minutes
-- 4.9/5 star rating from active users
-- 500+ professional resumes created monthly
+### Current product notes
+- Public pages include structured metadata and a sitemap.
+- The free plan stores entered provider keys in the browser's local storage.
+- ATS behavior and interview outcomes vary by employer; the product does not guarantee a hiring result.
 
 ## 🔮 Roadmap & Future Features
 
@@ -344,7 +331,7 @@ For businesses requiring proprietary licenses or commercial support, please cont
 
 **Ready to land your dream job?**
 
-[![Get Started Free](https://img.shields.io/badge/🚀_Get_Started_Free-resumelm.com-blue?style=for-the-badge&color=6366f1)](https://resumelm.com)
+[![Get Started](https://img.shields.io/badge/🚀_Get_Started-resumelm.ca-blue?style=for-the-badge&color=6366f1)](https://resumelm.ca)
 [![View Source Code](https://img.shields.io/badge/📚_View_Source-GitHub-black?style=for-the-badge&logo=github)](https://github.com/olyaiy/resume-lm)
 
 **Built with ❤️ using Next.js**

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "build": "next build",
     "start": "next start",
     "lint": "next lint",
+    "check:trust": "node scripts/check-public-contracts.mjs",
     "test": "node node_modules/.pnpm/tsx@4.19.4/node_modules/tsx/dist/cli.mjs --test \"src/**/*.test.ts\"",
     "typecheck": "tsc --noEmit --pretty false"
   },

--- a/scripts/check-public-contracts.mjs
+++ b/scripts/check-public-contracts.mjs
@@ -1,0 +1,46 @@
+import assert from "node:assert/strict";
+import { existsSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+
+const root = process.cwd();
+const publicSources = [
+  "README.md",
+  "src/app/page.tsx",
+  "src/components/landing/Hero.tsx",
+  "src/components/landing/FeatureHighlights.tsx",
+  "src/components/landing/PricingPlans.tsx",
+  "src/components/landing/pricing-section.tsx",
+  "src/components/pricing/optimized-subscription-page.tsx",
+  "src/components/settings/subscription-section.tsx",
+  "src/components/dashboard/api-key-alert.tsx",
+];
+
+const forbidden = [
+  "resumelm.com",
+  "resume-ai",
+  "No credit card required",
+  "50,000+",
+  "12,000+",
+  "1,800+",
+  "3x Higher Interview Rate",
+  "300% increase",
+  "30-day money-back guarantee",
+  "Priority job matching algorithm",
+  "Advanced analytics dashboard",
+  "coming soon",
+];
+
+for (const relativePath of publicSources) {
+  const content = readFileSync(join(root, relativePath), "utf8");
+  for (const phrase of forbidden) {
+    assert.equal(content.includes(phrase), false, `${relativePath} still contains stale trust copy: ${phrase}`);
+  }
+}
+
+assert.equal(existsSync(join(root, "public/ResumeLM.mp4")), true);
+assert.equal(existsSync(join(root, "public/logos/deepseek-logo-full.png")), true);
+for (const route of ["privacy", "terms", "refund", "security", "robots.ts", "sitemap.ts"]) {
+  assert.equal(existsSync(join(root, `src/app/${route}`)), true, `missing public route ${route}`);
+}
+
+console.log("Public contract checks passed");

--- a/src/app/(dashboard)/jobs/page.tsx
+++ b/src/app/(dashboard)/jobs/page.tsx
@@ -1,0 +1,22 @@
+import type { Metadata } from "next";
+
+import { JobListingsCard } from "@/components/jobs/job-listings-card";
+
+export const metadata: Metadata = {
+  title: "Job listings | ResumeLM",
+  description: "Review and manage job listings while tailoring your ResumeLM applications.",
+};
+
+export default function JobsPage() {
+  return (
+    <main className="min-h-screen bg-gradient-to-br from-rose-50/50 via-sky-50/50 to-violet-50/50 px-6 py-10">
+      <div className="mx-auto max-w-6xl space-y-6">
+        <div>
+          <h1 className="text-3xl font-semibold tracking-tight">Job listings</h1>
+          <p className="text-muted-foreground">Save opportunities and use them when creating tailored resumes.</p>
+        </div>
+        <JobListingsCard />
+      </div>
+    </main>
+  );
+}

--- a/src/app/(dashboard)/resumes/new/page.tsx
+++ b/src/app/(dashboard)/resumes/new/page.tsx
@@ -1,0 +1,5 @@
+import { redirect } from "next/navigation";
+
+export default function NewResumePage() {
+  redirect("/home");
+}

--- a/src/app/(dashboard)/start-trial/page.tsx
+++ b/src/app/(dashboard)/start-trial/page.tsx
@@ -7,7 +7,7 @@ import { Badge } from '@/components/ui/badge';
 import { 
   Check, 
   CreditCard,
-  Shield, 
+  Shield,
   Crown,
   Zap,
   ArrowRight,
@@ -25,9 +25,8 @@ const features = [
   "Unlimited base resumes",
   "Unlimited AI-tailored resumes",
   "Advanced AI assistance with multiple models",
-  "Premium ATS-optimized templates",
-  "Cover letter generation",
-  "Priority customer support"
+  "Unlimited resume versions",
+  "App-funded premium models"
 ];
 
 export default function StartTrialPage() {
@@ -117,8 +116,8 @@ export default function StartTrialPage() {
                     <Users className="h-4 w-4 text-purple-700" />
                   </div>
                   <div>
-                    <p className="text-sm font-medium text-gray-900">1,800+ users</p>
-                    <p className="text-xs text-gray-600">Growing every week</p>
+                    <p className="text-sm font-medium text-gray-900">Open source</p>
+                    <p className="text-xs text-gray-600">Self-hostable project</p>
                   </div>
                 </div>
               </div>
@@ -215,7 +214,7 @@ export default function StartTrialPage() {
               </Button>
 
               <p className="text-center text-xs text-gray-500 mt-4">
-                By starting your trial, you agree to our Terms of Service
+                By starting your trial, you agree to our <a href="/terms" className="underline">Terms of Service</a>. A payment method is required; cancel before the trial ends to avoid the recurring charge.
               </p>
             </div>
           </motion.div>

--- a/src/app/(dashboard)/subscription/checkout/success/page.tsx
+++ b/src/app/(dashboard)/subscription/checkout/success/page.tsx
@@ -16,8 +16,8 @@ const SuccessPage = () => {
                 <h3 className="text-lg font-semibold mb-4">Next Steps</h3>
                 <div className="space-y-2 text-sm">
                     <p>✓ Access to AI-powered resume tailoring</p>
-                    <p>✓ Priority job matching algorithm</p>
-                    <p>✓ Advanced analytics dashboard</p>
+                    <p>✓ Unlimited resume versions</p>
+                    <p>✓ App-funded premium AI models</p>
                 </div>
             </div>
         </div>

--- a/src/app/auth/confirm/route.ts
+++ b/src/app/auth/confirm/route.ts
@@ -3,13 +3,7 @@ import { type NextRequest } from 'next/server'
 
 import { createClient } from '@/utils/supabase/server'
 import { redirect } from 'next/navigation'
-
-function getSafeRedirectPath(path: string | null, fallback: string = '/') {
-  if (!path) return fallback
-  if (!path.startsWith('/')) return fallback
-  if (path.startsWith('//')) return fallback
-  return path
-}
+import { getSafeRedirectPath } from '@/lib/auth-intent'
 
 export async function GET(request: NextRequest) {
   const { searchParams } = new URL(request.url)

--- a/src/app/auth/login/actions.ts
+++ b/src/app/auth/login/actions.ts
@@ -12,9 +12,12 @@ import { getEmailSignupBlockedMessage, isEmailSignupAllowed } from "@/lib/auth-p
 import {
   AUTH_ERROR_CODES,
   buildAuthCallbackUrl,
+  getAuthRedirectPath,
+  getAuthIntentFromParams,
   getSafeRedirectPath,
   type AuthIntent,
 } from "@/lib/auth-intent";
+import { siteUrl } from "@/lib/site-config";
 
 // Auto-create Pro subscription for new users (for local development)
 const AUTO_PRO_SUBSCRIPTION = process.env.AUTO_PRO_SUBSCRIPTION === 'true';
@@ -39,6 +42,9 @@ function mapLoginErrorMessage(message?: string): string {
   if (normalized.includes("email not confirmed")) {
     return "Please confirm your email before signing in.";
   }
+  if (normalized.includes("too many requests")) {
+    return "Too many sign-in attempts. Please wait a moment and try again.";
+  }
 
   return message;
 }
@@ -55,10 +61,19 @@ export async function login(formData: FormData): Promise<AuthResult> {
   const { error } = await supabase.auth.signInWithPassword(data)
 
   if (error) {
-    return { success: false, error: error.message }
+    console.error('Password sign-in failed:', {
+      code: error.code ?? null,
+      message: error.message,
+      status: error.status ?? null,
+      name: error.name,
+    });
+    return { success: false, error: mapLoginErrorMessage(error.message), errorCode: error.code };
   }
 
-  const next = getSafeRedirectPath(formData.get('next') as string | null);
+  const next = getAuthRedirectPath(getAuthIntentFromParams({
+    next: formData.get('next') as string | null,
+    plan: formData.get('plan') as string | null,
+  }));
   redirect(next)
   return { success: true }
 }
@@ -71,6 +86,10 @@ export async function signup(formData: FormData): Promise<AuthResult> {
 
   const supabase = await createServiceClient();
 
+  const callbackUrl = new URL('/auth/confirm', siteUrl());
+  const safeNext = getSafeRedirectPath(formData.get('next') as string | null, '');
+  if (safeNext) callbackUrl.searchParams.set('next', safeNext);
+
   const data = {
     email: formData.get('email') as string,
     password: formData.get('password') as string,
@@ -78,7 +97,7 @@ export async function signup(formData: FormData): Promise<AuthResult> {
       data: {
         full_name: formData.get('name') as string,
       },
-      emailRedirectTo: `${process.env.NEXT_PUBLIC_SITE_URL}/auth/confirm`
+      emailRedirectTo: callbackUrl.toString()
     }
   }
   const { data: signupData, error: signupError } = await supabase.auth.signUp(data);

--- a/src/app/auth/login/page.tsx
+++ b/src/app/auth/login/page.tsx
@@ -15,6 +15,7 @@ import { NavLinks } from "@/components/layout/nav-links";
 import { ModelShowcase } from "@/components/landing/model-showcase";
 import { AuthDialogProvider } from "@/components/auth/auth-dialog-provider";
 import { AUTH_ERROR_CODES, getAuthIntentFromParams } from "@/lib/auth-intent";
+import { GITHUB_REPO_URL, siteUrl } from "@/lib/site-config";
 
 // import { WaitlistSection } from "@/components/waitlist/waitlist-section";
 
@@ -26,7 +27,7 @@ export const metadata: Metadata = {
   openGraph: {
     title: "ResumeLM - AI-Powered Resume Builder",
     description: "Create tailored, ATS-optimized resumes powered by AI. Land your dream tech job with personalized resume optimization.",
-    url: "https://resumelm.com//",
+    url: siteUrl("auth/login"),
     siteName: "ResumeLM",
     images: [
       {
@@ -46,17 +47,7 @@ export const metadata: Metadata = {
     images: ["/og.webp"],
     creator: "@resumelm",
   },
-  robots: {
-    index: true,
-    follow: true,
-    googleBot: {
-      index: true,
-      follow: true,
-      "max-video-preview": -1,
-      "max-image-preview": "large",
-      "max-snippet": -1,
-    },
-  },
+  robots: { index: false, follow: false },
   // verification: {
   //   google: "google-site-verification-code", // Replace with actual verification code
   // },
@@ -90,7 +81,7 @@ export default async function LoginPage({
         <nav className="border-b border-white/50 backdrop-blur-xl shadow-md fixed top-0 w-full bg-white/20 z-[1000] transition-all duration-500">
           <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
             <div className="flex items-center justify-between h-16">
-              <Logo />
+              <Logo href="/" />
               <NavLinks />
             </div>
           </div>
@@ -107,7 +98,7 @@ export default async function LoginPage({
                 <div className="space-y-8">
                   {/* GitHub Badge */}
                   <a
-                    href="https://github.com/olyaiy/resume-ai"
+                    href={GITHUB_REPO_URL}
                     target="_blank"
                     rel="noopener noreferrer"
                     className="inline-flex items-center gap-2.5 px-4 py-2 rounded-full 

--- a/src/app/auth/register/page.tsx
+++ b/src/app/auth/register/page.tsx
@@ -1,0 +1,5 @@
+import { redirect } from "next/navigation";
+
+export default function RegisterPage() {
+  redirect("/auth/login?next=%2Fhome");
+}

--- a/src/app/blog/[slug]/page.tsx
+++ b/src/app/blog/[slug]/page.tsx
@@ -2,6 +2,7 @@ import { compileMDX } from "next-mdx-remote/rsc";
 import { notFound } from "next/navigation";
 import { Metadata } from "next";
 import { getAllPosts, getPostBySlug } from "@/lib/blog";
+import { siteUrl } from "@/lib/site-config";
 import { toSafeJsonScript } from "@/lib/html-safety";
 import { mdxComponents } from "@/components/blog/mdx-components";
 import { Calendar, ArrowLeft, Clock } from "lucide-react";
@@ -21,7 +22,7 @@ export async function generateMetadata({ params }: BlogPostPageProps): Promise<M
   const post = getPostBySlug(slug);
   if (!post) return {};
   
-  const url = `https://resumelm.com/blog/${slug}`;
+  const url = siteUrl(`/blog/${slug}`);
   const publishedTime = new Date(post.frontMatter.date).toISOString();
   
   return {
@@ -96,26 +97,26 @@ export default async function BlogPostPage({ params }: BlogPostPageProps) {
     '@type': 'Article',
     headline: post.frontMatter.title,
     description: post.frontMatter.description,
-    image: 'https://resumelm.com/og.webp',
+    image: siteUrl('/og.webp'),
     datePublished: new Date(post.frontMatter.date).toISOString(),
     dateModified: new Date(post.frontMatter.date).toISOString(),
     author: {
       '@type': 'Organization',
       name: 'ResumeLM Team',
-      url: 'https://resumelm.com',
+      url: siteUrl(),
     },
     publisher: {
       '@type': 'Organization',
       name: 'ResumeLM',
       logo: {
         '@type': 'ImageObject',
-        url: 'https://resumelm.com/og.webp',
+          url: siteUrl('/og.webp'),
       },
-      url: 'https://resumelm.com',
+      url: siteUrl(),
     },
     mainEntityOfPage: {
       '@type': 'WebPage',
-      '@id': `https://resumelm.com/blog/${slug}`,
+      '@id': siteUrl(`/blog/${slug}`),
     },
     articleSection: 'Career Advice',
     keywords: 'resume builder, tech jobs, Vancouver tech, career advice, AI resume, job search',

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -15,12 +15,16 @@ import {
 } from "@/lib/impersonation";
 import { getSubscriptionAccessState } from "@/lib/subscription-access";
 import { Suspense } from "react";
+import { SITE_URL } from "@/lib/site-config";
 
 // Only enable Vercel Analytics when running on Vercel platform
 const isVercel = process.env.VERCEL === '1';
 
 export const metadata: Metadata = {
-  metadataBase: new URL("https://resumelm.com"),
+  metadataBase: new URL(SITE_URL),
+  alternates: {
+    canonical: SITE_URL,
+  },
   title: {
     default: "ResumeLM - AI-Powered Resume Builder",
     template: "%s | ResumeLM"

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -14,19 +14,20 @@ import { Metadata } from "next";
 import Script from "next/script";
 import { toSafeJsonScript } from "@/lib/html-safety";
 import { AuthDialogProvider } from "@/components/auth/auth-dialog-provider";
+import { siteUrl } from "@/lib/site-config";
 
 // Page-specific metadata that extends the base metadata from layout.tsx
 export const metadata: Metadata = {
   title: "ResumeLM - AI Resume Builder for Tech Jobs",
-  description: "Create ATS-optimized tech resumes in under 10 minutes. 3x your interview chances with AI-powered resume tailoring.",
+  description: "Create and tailor tech resumes with an open-source AI resume builder.",
   openGraph: {
     title: "ResumeLM - AI Resume Builder for Tech Jobs",
-    description: "Create ATS-optimized tech resumes in under 10 minutes. 3x your interview chances with AI-powered resume tailoring.",
-    url: "https://resumelm.com",
+    description: "Create and tailor tech resumes with an open-source AI resume builder.",
+    url: siteUrl(),
   },
   twitter: {
     title: "ResumeLM - AI Resume Builder for Tech Jobs",
-    description: "Create ATS-optimized tech resumes in under 10 minutes. 3x your interview chances with AI-powered resume tailoring.",
+    description: "Create and tailor tech resumes with an open-source AI resume builder.",
   },
 };
 
@@ -45,18 +46,28 @@ export default async function Page() {
     "@type": "SoftwareApplication",
     "name": "ResumeLM",
     "applicationCategory": "BusinessApplication",
-    "offers": {
-      "@type": "Offer",
-      "price": "0",
-      "priceCurrency": "USD"
-    },
-    "description": "Create ATS-optimized tech resumes in under 10 minutes. 3x your interview chances with AI-powered resume tailoring.",
+    "offers": [
+      {
+        "@type": "Offer",
+        "name": "Free plan",
+        "price": "0",
+        "priceCurrency": "USD"
+      },
+      {
+        "@type": "Offer",
+        "name": "Pro plan",
+        "price": "20",
+        "priceCurrency": "USD",
+        "priceSpecification": {
+          "@type": "UnitPriceSpecification",
+          "price": "20",
+          "priceCurrency": "USD",
+          "unitText": "MONTH"
+        }
+      }
+    ],
+    "description": "Create and tailor tech resumes with an open-source AI resume builder.",
     "operatingSystem": "Web",
-    "aggregateRating": {
-      "@type": "AggregateRating",
-      "ratingValue": "4.8",
-      "ratingCount": "500"
-    }
   };
   
   return (
@@ -76,7 +87,7 @@ export default async function Page() {
           <nav aria-label="Main navigation" className="border-b border-gray-200 fixed top-0 w-full bg-white/95 z-[1000] transition-all duration-300 shadow-sm">
             <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
               <div className="flex items-center justify-between h-16">
-                <Logo />
+            <Logo href="/" />
                 <NavLinks />
               </div>
             </div>

--- a/src/app/privacy/page.tsx
+++ b/src/app/privacy/page.tsx
@@ -1,0 +1,32 @@
+import type { Metadata } from "next";
+import { LegalPage } from "@/components/legal/legal-page";
+import { siteUrl } from "@/lib/site-config";
+
+export const metadata: Metadata = {
+  title: "Privacy Policy",
+  alternates: { canonical: siteUrl("privacy") },
+  robots: { index: true, follow: true },
+};
+
+export default function PrivacyPage() {
+  return (
+    <LegalPage title="Privacy Policy" updated="August 1, 2026">
+      <h2>What ResumeLM stores</h2>
+      <p>
+        ResumeLM stores account, profile, resume, subscription, and usage data needed to provide the service. Resume content is associated with your account so it can be edited, exported, and tailored.
+      </p>
+      <h2>Service providers</h2>
+      <p>
+        ResumeLM uses Supabase for authentication and application data, Stripe for billing, PostHog for product analytics, and configured AI providers to process AI requests. These providers process data only as needed to provide their services under their own terms and privacy policies.
+      </p>
+      <h2>API keys</h2>
+      <p>
+        API keys that you add yourself are stored in this browser&apos;s local storage. They are not encrypted by ResumeLM, so do not use this feature on a shared or untrusted device. Pro requests may use ResumeLM&apos;s server-side provider credentials for eligible models.
+      </p>
+      <h2>Your choices</h2>
+      <p>
+        You may self-host the open-source application, remove locally stored API keys from Settings, or contact <a href="mailto:resumelm@pm.me">resumelm@pm.me</a> with privacy questions or deletion requests.
+      </p>
+    </LegalPage>
+  );
+}

--- a/src/app/refund/page.tsx
+++ b/src/app/refund/page.tsx
@@ -1,0 +1,28 @@
+import type { Metadata } from "next";
+import { LegalPage } from "@/components/legal/legal-page";
+import { siteUrl } from "@/lib/site-config";
+
+export const metadata: Metadata = {
+  title: "Refund Policy",
+  alternates: { canonical: siteUrl("refund") },
+  robots: { index: true, follow: true },
+};
+
+export default function RefundPage() {
+  return (
+    <LegalPage title="Refund Policy" updated="August 1, 2026">
+      <h2>Billing issues</h2>
+      <p>
+        Contact <a href="mailto:resumelm@pm.me">resumelm@pm.me</a> as soon as possible if you believe a payment was duplicated, unauthorized, or otherwise incorrect. Include the billing email and relevant Stripe receipt information; do not send full card numbers.
+      </p>
+      <h2>Subscription cancellation</h2>
+      <p>
+        You can cancel through the Stripe billing portal. Cancellation prevents future renewals; access remains available according to the subscription state shown in the application.
+      </p>
+      <h2>Refund decisions</h2>
+      <p>
+        Refund requests are reviewed individually. ResumeLM does not currently advertise an automatic money-back guarantee. Approved refunds are returned through Stripe to the original payment method.
+      </p>
+    </LegalPage>
+  );
+}

--- a/src/app/robots.ts
+++ b/src/app/robots.ts
@@ -1,0 +1,10 @@
+import type { MetadataRoute } from "next";
+import { siteUrl } from "@/lib/site-config";
+
+export default function robots(): MetadataRoute.Robots {
+  return {
+    rules: [{ userAgent: "*", allow: ["/", "/blog/"], disallow: ["/api/", "/admin/", "/auth/", "/home/", "/profile/", "/resumes/", "/settings/", "/subscription/"] }],
+    sitemap: siteUrl("sitemap.xml"),
+    host: siteUrl(),
+  };
+}

--- a/src/app/security/page.tsx
+++ b/src/app/security/page.tsx
@@ -1,0 +1,24 @@
+import type { Metadata } from "next";
+import { LegalPage } from "@/components/legal/legal-page";
+import { siteUrl } from "@/lib/site-config";
+
+export const metadata: Metadata = {
+  title: "Security",
+  alternates: { canonical: siteUrl("security") },
+  robots: { index: true, follow: true },
+};
+
+export default function SecurityPage() {
+  return (
+    <LegalPage title="Security" updated="August 1, 2026">
+      <h2>Application controls</h2>
+      <p>
+        ResumeLM uses Supabase authentication and row-level access controls for application data. Billing events are processed server-side through Stripe, and provider secrets are kept in server environment variables rather than sent to the browser.
+      </p>
+      <h2>Limits of the service</h2>
+      <p>
+        No online service can guarantee absolute security. API keys entered into the browser are stored in local storage and should not be entered on shared devices. Please report suspected security issues to <a href="mailto:resumelm@pm.me">resumelm@pm.me</a>.
+      </p>
+    </LegalPage>
+  );
+}

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -1,0 +1,17 @@
+import type { MetadataRoute } from "next";
+import { getAllPosts } from "@/lib/blog";
+import { siteUrl } from "@/lib/site-config";
+
+export default function sitemap(): MetadataRoute.Sitemap {
+  const staticPages = ["", "/blog", "/privacy", "/terms", "/refund", "/security"].map((path) => ({
+    url: siteUrl(path),
+    lastModified: new Date(),
+  }));
+
+  const blogPages = getAllPosts().map((post) => ({
+    url: siteUrl(`/blog/${post.slug}`),
+    lastModified: new Date(post.frontMatter.date),
+  }));
+
+  return [...staticPages, ...blogPages];
+}

--- a/src/app/terms/page.tsx
+++ b/src/app/terms/page.tsx
@@ -1,0 +1,32 @@
+import type { Metadata } from "next";
+import { LegalPage } from "@/components/legal/legal-page";
+import { siteUrl } from "@/lib/site-config";
+
+export const metadata: Metadata = {
+  title: "Terms of Service",
+  alternates: { canonical: siteUrl("terms") },
+  robots: { index: true, follow: true },
+};
+
+export default function TermsPage() {
+  return (
+    <LegalPage title="Terms of Service" updated="August 1, 2026">
+      <h2>Using ResumeLM</h2>
+      <p>
+        ResumeLM provides resume editing, tailoring, export, and related AI-assisted tools. You are responsible for the accuracy of information you submit and for reviewing generated content before using it in an application.
+      </p>
+      <h2>AI output</h2>
+      <p>
+        AI suggestions are generated from the information and instructions provided. ResumeLM does not guarantee interviews, employment, ATS ranking, or any other hiring outcome.
+      </p>
+      <h2>Subscriptions and trials</h2>
+      <p>
+        Pro subscriptions are billed at the price shown at checkout. A trial, when offered, requires a payment method and converts to the displayed recurring subscription unless canceled before the trial ends. Billing and cancellation are managed through Stripe.
+      </p>
+      <h2>Contact</h2>
+      <p>
+        Questions about these terms can be sent to <a href="mailto:resumelm@pm.me">resumelm@pm.me</a>.
+      </p>
+    </LegalPage>
+  );
+}

--- a/src/components/auth/auth-dialog-provider.tsx
+++ b/src/components/auth/auth-dialog-provider.tsx
@@ -5,6 +5,7 @@ import { Loader2 } from "lucide-react";
 
 import { signInWithGoogle } from "@/app/auth/login/actions";
 import { LoginForm } from "@/components/auth/login-form";
+import { SignupForm } from "@/components/auth/signup-form";
 import { Alert, AlertDescription } from "@/components/ui/alert";
 import { Button } from "@/components/ui/button";
 import { Dialog, DialogContent, DialogDescription, DialogTitle } from "@/components/ui/dialog";
@@ -199,16 +200,25 @@ export function AuthDialogProvider({
                     <h3 className="text-lg font-semibold text-slate-900">Welcome back</h3>
                     <p className="text-sm text-slate-600 mt-1">Sign in to continue</p>
                   </div>
-                  <LoginForm key={`login-${formVersion}`} next={intent?.next} />
+                  <LoginForm
+                    key={`login-${formVersion}`}
+                    next={intent?.next ?? (intent?.plan === "pro" ? "/subscription" : undefined)}
+                    plan={intent?.plan}
+                  />
                   <SocialAuth intent={intent} />
                 </TabsContent>
 
                 <TabsContent value="signup" className="mt-0 space-y-4">
                   <div className="text-center mb-4">
                     <h3 className="text-lg font-semibold text-slate-900">Get started</h3>
-                    <p className="text-sm text-slate-600 mt-1">Create your free account with Google</p>
+                    <p className="text-sm text-slate-600 mt-1">Create an account with email or Google</p>
                   </div>
-                  <SocialAuth showDivider={false} intent={intent} />
+                  <SignupForm
+                    key={`signup-${formVersion}`}
+                    next={intent?.next ?? (intent?.plan === "pro" ? "/subscription" : undefined)}
+                    plan={intent?.plan}
+                  />
+                  <SocialAuth intent={intent} />
                 </TabsContent>
               </div>
             </Tabs>

--- a/src/components/auth/login-form.tsx
+++ b/src/components/auth/login-form.tsx
@@ -33,7 +33,7 @@ function SubmitButton() {
   );
 }
 
-export function LoginForm({ next }: { next?: string }) {
+export function LoginForm({ next, plan }: { next?: string; plan?: "free" | "pro" }) {
   const [state, formAction] = useActionState(loginWithState, initialAuthFormState);
   const [showPassword, setShowPassword] = useState(false);
 
@@ -43,6 +43,7 @@ export function LoginForm({ next }: { next?: string }) {
   return (
     <form action={formAction} className="space-y-5">
       {next && <input type="hidden" name="next" value={next} />}
+      {plan && <input type="hidden" name="plan" value={plan} />}
       <div className="space-y-2">
         <Label htmlFor="login-email" className="text-sm font-medium">
           Email

--- a/src/components/auth/signup-form.tsx
+++ b/src/components/auth/signup-form.tsx
@@ -13,6 +13,8 @@ import { Label } from "@/components/ui/label";
 
 interface SignupFormProps {
   onSuccess?: () => void;
+  next?: string;
+  plan?: "free" | "pro";
 }
 
 function SubmitButton() {
@@ -36,7 +38,7 @@ function SubmitButton() {
   );
 }
 
-export function SignupForm({ onSuccess }: SignupFormProps) {
+export function SignupForm({ onSuccess, next, plan }: SignupFormProps) {
   const [state, formAction] = useActionState(signupWithState, initialAuthFormState);
   const [showPassword, setShowPassword] = useState(false);
   const hasHandledSuccess = useRef(false);
@@ -71,6 +73,8 @@ export function SignupForm({ onSuccess }: SignupFormProps) {
 
   return (
     <form action={formAction} className="space-y-4">
+      {next && <input type="hidden" name="next" value={next} />}
+      {plan && <input type="hidden" name="plan" value={plan} />}
       <div className="space-y-2">
         <Label htmlFor="signup-name" className="text-sm font-medium">
           Full Name

--- a/src/components/dashboard/api-key-alert.tsx
+++ b/src/components/dashboard/api-key-alert.tsx
@@ -56,13 +56,13 @@ export function ApiKeyAlert({ variant = 'upgrade' }: { variant?: ApiKeyAlertVari
                 </div>
                 
                 <div className="flex items-center gap-4 text-xs text-gray-600 mb-2">
-                  <span className="flex items-center gap-1">🚀 Unlimited resumes</span>
-                  <span className="flex items-center gap-1">🤖 Latest AI models</span>
+                  <span className="flex items-center gap-1">🚀 Unlimited resume versions</span>
+                  <span className="flex items-center gap-1">🤖 App-funded models</span>
                   <span className="flex items-center gap-1">⚡ Instant access</span>
                 </div>
 
                 <p className="text-xs text-gray-500">
-                  {variant === 'trial' ? 'Join 1,800+ users building with ResumeLM' : 'Join 1,800+ users building with ResumeLM'}
+                  Pro is $20/month after the 7-day trial; a payment method is required to start.
                 </p>
               </div>
 

--- a/src/components/landing/FAQ.tsx
+++ b/src/components/landing/FAQ.tsx
@@ -31,11 +31,11 @@ export function FAQ() {
     },
     {
       question: "How long does it take to create a resume with ResumeLM?",
-      answer: "Most users create their first resume in under 15 minutes. Once you have a base resume, generating tailored versions for specific jobs takes just 2-3 minutes with our AI assistant."
+      answer: "The time varies with the amount of information you provide. Once you have a base resume, you can generate tailored versions for specific jobs with the AI assistant."
     },
     {
       question: "Will my resume pass ATS (Applicant Tracking Systems)?",
-      answer: "Absolutely! ResumeLM is specifically designed to create ATS-optimized resumes. Our templates use proper formatting, keyword optimization, and structure that ATS systems can easily parse and rank highly."
+      answer: "ResumeLM uses ATS-aware formatting, structure, and keyword suggestions. ATS behavior varies by employer, so no resume tool can guarantee a particular screening outcome."
     },
     {
       question: "Can I use my own AI API keys?",
@@ -43,7 +43,7 @@ export function FAQ() {
     },
     {
       question: "Is my data secure and private?",
-      answer: "Your privacy is our priority. All data is encrypted, and you can even self-host ResumeLM for complete control. We never share your personal information or resume data with third parties."
+      answer: "Resume data is stored in the configured Supabase project, payments are handled by Stripe, and product analytics are handled by PostHog. API keys entered in the free plan stay in this browser's local storage. Review the Privacy and Security pages for details."
     },
     {
       question: "Do you offer support for students or career changers?",
@@ -153,4 +153,4 @@ export function FAQ() {
       </motion.div>
     </section>
   );
-} 
+}

--- a/src/components/landing/FeatureHighlights.tsx
+++ b/src/components/landing/FeatureHighlights.tsx
@@ -1,6 +1,5 @@
 "use client"
 import React from 'react';
-import Image from "next/image";
 import { motion } from "framer-motion";
 import { CheckCircle2 } from "lucide-react";
 import Link from "next/link";
@@ -11,21 +10,11 @@ const FeatureHighlights = () => {
   // Enhanced features with metrics, testimonials, and benefit-focused language
 
 
-  // Trusted by logos
-  const companies = [
-    { name: "Google", logo: "/logos/google.png" },
-    { name: "Microsoft", logo: "/logos/microsoft.webp" },
-    { name: "Amazon", logo: "/logos/amazon.png" },
-    { name: "Meta", logo: "/logos/meta.png" },
-    { name: "Netflix", logo: "/logos/netflix.png" },
-  ];
-
-  // Statistics counters
   const stats = [
-    { value: "500+", label: "Resumes Created" },
-    { value: "89%", label: "Interview Rate" },
-    { value: "4.9/5", label: "User Rating" },
-    { value: "15 min", label: "Average Setup Time" },
+    { value: "Open source", label: "Self-hostable" },
+    { value: "BYOK", label: "Free plan" },
+    { value: "PDF", label: "Export format" },
+    { value: "$20", label: "Pro per month" },
   ];
 
   // Animation variants for scroll reveal
@@ -79,7 +68,7 @@ const FeatureHighlights = () => {
             ATS-Optimized
           </span>
           <span className="px-3 py-1 rounded-full bg-gradient-to-r from-emerald-600/10 to-green-600/10 border border-emerald-200/40 text-sm text-emerald-700">
-            100% Free
+            Free plan available
           </span>
         </motion.div>
         
@@ -111,7 +100,7 @@ const FeatureHighlights = () => {
             transition={{ duration: 0.6, delay: 0.7 }}
             className="text-lg md:text-xl text-muted-foreground max-w-2xl mx-auto mt-3"
           >
-            Smart AI tools that optimize your resume for each job, increasing your interview chances by up to <span className="font-semibold text-teal-700">3x</span>
+            Smart AI tools that help you build a base resume and tailor it to each job.
           </motion.p>
         </motion.div>
 
@@ -181,7 +170,7 @@ const FeatureHighlights = () => {
               description="Get real-time feedback and suggestions from our advanced AI assistant. Optimize your resume content, improve your bullet points, and ensure your skills stand out to recruiters and ATS systems."
               imageOnLeft={false}
               imageOverflowRight={true}
-              badgeText="90% more effective bullets"
+              badgeText="AI-assisted editing"
               badgeGradient="from-purple-600/10 to-indigo-600/10"
               bulletPoints={[
                 "Smart content suggestions based on your experience",
@@ -210,7 +199,7 @@ const FeatureHighlights = () => {
               description="Get detailed insights into your resume's effectiveness with our comprehensive scoring system. Track key metrics, identify areas for improvement, and optimize your resume to stand out to employers and ATS systems."
               imageOnLeft={false}
               imageOverflowRight={true}
-              badgeText="3x higher response rates"
+              badgeText="ATS-aware feedback"
               badgeGradient="from-pink-600/10 to-rose-600/10"
               bulletPoints={[
                 "ATS compatibility scoring",
@@ -234,30 +223,6 @@ const FeatureHighlights = () => {
             />
       </div>
       
-      {/* Social proof section - Trusted by companies */}
-      <motion.div 
-        className="mt-24 text-center"
-        initial={{ opacity: 0, y: 20 }}
-        whileInView={{ opacity: 1, y: 0 }}
-        viewport={{ once: true, margin: "-100px" }}
-        transition={{ duration: 0.8 }}
-      >
-        <h3 className="text-xl text-muted-foreground mb-8">Trusted by professionals from companies like</h3>
-        <div className="flex flex-wrap justify-center items-center gap-8 md:gap-12 max-w-4xl mx-auto opacity-80">
-          {companies.map((company, index) => (
-            <div key={index} className="w-24 h-12 relative transition-all duration-300">
-              <Image 
-                src={company.logo} 
-                alt={company.name} 
-                fill
-                className="object-contain" 
-                sizes="100px"
-              />
-            </div>
-          ))}
-        </div>
-      </motion.div>
-      
       {/* Enhanced CTA section */}
       <motion.div 
         className="mt-28 text-center"
@@ -273,7 +238,7 @@ const FeatureHighlights = () => {
             </span>
           </h2>
           <p className="text-lg text-muted-foreground mb-8">
-            Join 50,000+ professionals who are getting more interviews with ResumeLM
+            Start with the free plan, bring your own API keys, and upgrade to Pro when you want app-funded models.
           </p>
           
           <div className="flex flex-col sm:flex-row gap-4 justify-center">
@@ -298,7 +263,7 @@ const FeatureHighlights = () => {
           
           <p className="text-sm text-muted-foreground mt-6 flex items-center justify-center gap-2">
             <CheckCircle2 className="w-4 h-4 text-green-500" />
-            No credit card required • 100% free
+            Free plan available • Pro is $20/month • Trial requires a payment method
           </p>
         </div>
       </motion.div>

--- a/src/components/landing/Hero.tsx
+++ b/src/components/landing/Hero.tsx
@@ -1,6 +1,4 @@
-import { Avatar, AvatarFallback } from "@/components/ui/avatar";
 import Link from "next/link";
-import Image from "next/image";
 import { AuthDialog } from "@/components/auth/auth-dialog";
 
 export function Hero() {
@@ -8,23 +6,6 @@ export function Hero() {
     <section className="flex flex-col lg:flex-row items-center gap-8 lg:gap-16 py-12 md:py-16 lg:py-20">
       {/* Left Content */}
       <div className="w-full lg:w-1/2 space-y-8">
-        {/* Product Hunt Badge */}
-        <div className="flex justify-start">
-          <a 
-            href="https://www.producthunt.com/products/resumelm?embed=true&utm_source=badge-featured&utm_medium=badge&utm_source=badge-resumelm" 
-            target="_blank"
-            rel="noopener noreferrer"
-            className="inline-block transition-transform duration-300 hover:-translate-y-1"
-          >
-            <Image 
-              src="https://api.producthunt.com/widgets/embed-image/v1/featured.svg?post_id=982199&theme=light&t=1750633039421" 
-              alt="ResumeLM - Open Source AI Resume Builder for Tech Jobs | Product Hunt" 
-              width={250} 
-              height={54} 
-            />
-          </a>
-        </div>
-        
         {/* Tagline with simplified gradient text */}
         <h1 className="text-4xl md:text-5xl lg:text-6xl font-bold tracking-tight">
           <span className="block">Open source</span>
@@ -34,7 +15,7 @@ export function Hero() {
         
         {/* Description with quantifiable benefits */}
         <p className="text-lg md:text-xl text-muted-foreground max-w-md">
-          Create ATS-optimized tech resumes in under 10 minutes. 3x your interview chances with AI-powered resume tailoring.
+          Create ATS-aware tech resumes with AI-powered resume tailoring.
         </p>
         
         {/* CTAs with simplified effects */}
@@ -65,48 +46,24 @@ export function Hero() {
         <div className="flex flex-wrap gap-3 mt-6">
           <span className="px-3 py-1 rounded-full bg-indigo-50 text-sm border border-indigo-200 text-indigo-700">AI-Powered</span>
           <span className="px-3 py-1 rounded-full bg-teal-50 text-sm border border-teal-200 text-teal-700">ATS-Optimized</span>
-          <span className="px-3 py-1 rounded-full bg-emerald-50 text-sm border border-emerald-200 text-emerald-700">100% Free</span>
+          <span className="px-3 py-1 rounded-full bg-emerald-50 text-sm border border-emerald-200 text-emerald-700">Free plan</span>
           <span className="px-3 py-1 rounded-full bg-blue-50 text-sm border border-blue-200 text-blue-700">Privacy-First</span>
         </div>
         
-        {/* Simplified social proof section */}
+        {/* Factual product summary */}
         <div className="mt-8">
           <div className="flex items-center p-4 rounded-xl bg-white border border-gray-200 shadow-sm transition-all duration-300 hover:-translate-y-1">
             {/* Stats highlight with simplified styling */}
             <div className="flex-shrink-0 mr-5">
               <div className="flex items-center justify-center h-16 w-16 rounded-full bg-indigo-50 border border-indigo-100">
-                <span className="text-2xl font-bold text-indigo-600">500+</span>
+                <span className="text-2xl font-bold text-indigo-600">BYOK</span>
               </div>
             </div>
             
             {/* Text content with testimonial */}
             <div className="flex-1">
               <h3 className="font-semibold text-base">Join our growing community</h3>
-              <p className="text-sm text-muted-foreground">Trusted by over 500 tech professionals</p>
-              
-              <p className="text-xs italic mt-1 text-indigo-600">&ldquo;Landed 3 interviews in my first week using ResumeLM&rdquo; — Sarah K.</p>
-              
-              {/* Shadcn Avatar stack */}
-              <div className="flex items-center mt-3">
-                <div className="flex -space-x-2 mr-3">
-                  <Avatar className="h-7 w-7 border-2 border-background">
-                    <AvatarFallback className="bg-indigo-500 text-white text-xs">JD</AvatarFallback>
-                  </Avatar>
-                  <Avatar className="h-7 w-7 border-2 border-background">
-                    <AvatarFallback className="bg-pink-500 text-white text-xs">SR</AvatarFallback>
-                  </Avatar>
-                  <Avatar className="h-7 w-7 border-2 border-background">
-                    <AvatarFallback className="bg-teal-500 text-white text-xs">KL</AvatarFallback>
-                  </Avatar>
-                  <Avatar className="h-7 w-7 border-2 border-background">
-                    <AvatarFallback className="bg-amber-500 text-white text-xs">MP</AvatarFallback>
-                  </Avatar>
-                  <Avatar className="h-7 w-7 border-2 border-background">
-                    <AvatarFallback className="bg-white text-xs text-indigo-600 font-medium">496+</AvatarFallback>
-                  </Avatar>
-                </div>
-                <span className="text-xs text-muted-foreground">Active this month</span>
-              </div>
+              <p className="text-sm text-muted-foreground">Use your own API keys on the free plan, or choose Pro for app-funded models.</p>
             </div>
           </div>
         </div>
@@ -191,4 +148,4 @@ export function Hero() {
       </div>
     </section>
   );
-} 
+}

--- a/src/components/landing/PricingPlans.tsx
+++ b/src/components/landing/PricingPlans.tsx
@@ -4,6 +4,7 @@ import { useMemo, useRef } from "react";
 import { Check, Sparkles } from "lucide-react";
 import { motion, useInView } from "framer-motion";
 import { AuthDialog } from "@/components/auth/auth-dialog";
+import { PLAN_CONFIG } from "@/lib/plans";
 
 interface PlanFeature {
   text: string;
@@ -33,35 +34,23 @@ export function PricingPlans() {
   const plans = useMemo<PricingPlan[]>(() => [
     {
       plan: "free",
-      name: "Free",
-      price: "$0",
-      description: "Self-host or use with your own API keys",
-      features: [
-        { text: "Use your own API keys" },
-        { text: "2 base resumes" },
-        { text: "5 tailored resumes" },
-        { text: "Self-host option available" },
-      ],
+      ...PLAN_CONFIG.free,
+      features: PLAN_CONFIG.free.features.map((text) => ({ text })),
       ctaText: "Get Started",
-      ctaLink: "/auth/register",
+      ctaLink: "/auth/login",
       ctaSecondary: true,
     },
     {
       plan: "pro",
-      name: "Pro",
-      price: "$20",
-      period: "/month",
-      description: "Enhanced features for serious job seekers",
+      ...PLAN_CONFIG.pro,
       badge: "Most Popular",
       popular: true,
-      features: [
-        { text: "Access to all premium AI models", highlight: true },
-        { text: "Unlimited base resumes", highlight: true },
-        { text: "Unlimited tailored resumes", highlight: true },
-        { text: "Support an independent student developer ❤️" },
-      ],
+      features: PLAN_CONFIG.pro.features.map((text) => ({
+        text,
+        highlight: text.includes("premium") || text.includes("Unlimited"),
+      })),
       ctaText: "Get Started",
-      ctaLink: "/auth/register",
+      ctaLink: "/auth/login",
     }
   ], []);
 

--- a/src/components/landing/action-buttons.tsx
+++ b/src/components/landing/action-buttons.tsx
@@ -3,6 +3,7 @@
 import { Button } from "@/components/ui/button";
 import { Github } from "lucide-react";
 import { AuthDialog } from "@/components/auth/auth-dialog";
+import { GITHUB_REPO_URL } from "@/lib/site-config";
 // import { WaitlistDialog } from "@/components/waitlist/waitlist-dialog";
 
 export function ActionButtons() {
@@ -17,11 +18,11 @@ export function ActionButtons() {
         size="sm" 
         variant="ghost" 
         className="text-xs text-muted-foreground hover:text-foreground border-none px-4 py-2 transition-colors duration-300 self-start"
-        onClick={() => window.open('https://github.com/olyaiy/resume-ai', '_blank')}
+        onClick={() => window.open(GITHUB_REPO_URL, '_blank')}
       >
         <Github className="mr-2 w-3.5 h-3.5" />
         Source Code on GitHub
       </Button>
     </div>
   );
-} 
+}

--- a/src/components/landing/github-badge.tsx
+++ b/src/components/landing/github-badge.tsx
@@ -1,15 +1,16 @@
 'use client';
 
 import { Github, ChevronRight } from "lucide-react";
+import { GITHUB_REPO_URL } from "@/lib/site-config";
 
 export function GitHubBadge() {
   return (
     <div 
-      onClick={() => window.open('https://github.com/olyaiy/resume-ai', '_blank')}
+      onClick={() => window.open(GITHUB_REPO_URL, '_blank')}
       className="inline-flex items-center gap-2.5 px-5 py-2.5 rounded-full bg-purple-50/80 border border-purple-200 text-purple-600 w-fit cursor-pointer hover:bg-purple-100/80 transition-colors">
       <Github className="w-4 h-4" />
       <span className="text-sm font-medium">Open Source on GitHub</span>
       <ChevronRight className="w-4 h-4" />
     </div>
   );
-} 
+}

--- a/src/components/landing/model-showcase.tsx
+++ b/src/components/landing/model-showcase.tsx
@@ -43,7 +43,7 @@ export function ModelShowcase() {
               {/* Deepseek Logo */}
               <div className="relative w-48 h-12 transition-transform duration-500 hover:scale-105">
                 <Image
-                  src="/deepseek-logo-full.png"
+                  src="/logos/deepseek-logo-full.png"
                   alt="Deepseek"
                   fill
                   className="object-contain"
@@ -65,4 +65,4 @@ export function ModelShowcase() {
       </div>
     </div>
   );
-} 
+}

--- a/src/components/landing/pricing-section.tsx
+++ b/src/components/landing/pricing-section.tsx
@@ -2,6 +2,7 @@ import { Check } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
 import { AuthDialog } from "@/components/auth/auth-dialog";
+import { PLAN_CONFIG } from "@/lib/plans";
 
 interface PricingFeature {
   text: string;
@@ -22,30 +23,24 @@ interface PricingTier {
 const tiers: PricingTier[] = [
   {
     plan: "free",
-    name: "Free",
-    price: "$0",
-    description: "Self-host or use with your own API keys",
+    name: PLAN_CONFIG.free.name,
+    price: PLAN_CONFIG.free.price,
+    description: PLAN_CONFIG.free.description,
     gradient: "from-violet-600/80 to-indigo-600/80",
     features: [
-      { text: "Use your own API keys", included: true },
-      { text: "2 base resumes", included: true },
-      { text: "5 tailored resumes", included: true },
-      { text: "Self-host option available", included: true },
+      ...PLAN_CONFIG.free.features.map((text) => ({ text, included: true })),
     ],
     buttonText: "Get Started",
   },
   {
     plan: "pro",
-    name: "Pro",
-    price: "$20",
-    description: "Enhanced features for serious job seekers",
+    name: PLAN_CONFIG.pro.name,
+    price: PLAN_CONFIG.pro.price,
+    description: PLAN_CONFIG.pro.description,
     gradient: "from-pink-600/80 to-rose-600/80",
     popular: true,
     features: [
-      { text: "Access to all premium AI models", included: true },
-      { text: "Unlimited base resumes", included: true },
-      { text: "Unlimited tailored resumes", included: true },
-      { text: "Support an independent student developer ❤️", included: true },
+      ...PLAN_CONFIG.pro.features.map((text) => ({ text, included: true })),
     ],
     buttonText: "Get Started",
   },
@@ -73,7 +68,7 @@ export function PricingSection() {
               </span>
             </div>
             <p className="text-sm text-muted-foreground hover:text-violet-600 transition-colors duration-300">
-              ResumeLM is open source and free to use. Pro version with managed API keys coming soon!
+              ResumeLM is open source. The free plan uses your own API keys; Pro includes app-funded premium models for $20/month.
             </p>
           </div>
         </div>
@@ -90,7 +85,7 @@ export function PricingSection() {
             >
               {tier.popular && (
                 <div className="absolute -top-6 left-0 right-0 mx-auto w-36 rounded-full bg-gradient-to-r from-pink-600 to-rose-600 px-4 py-1.5 text-sm text-white text-center font-medium shadow-lg">
-                  Coming Soon
+                  Most Popular
                 </div>
               )}
 

--- a/src/components/layout/footer.tsx
+++ b/src/components/layout/footer.tsx
@@ -1,5 +1,6 @@
 import Link from "next/link";
 import { Github, Linkedin, Twitter, Mail } from "lucide-react";
+import { CREATOR_LINKEDIN_URL, CREATOR_X_URL, SUPPORT_EMAIL } from "@/lib/site-config";
 
 interface FooterProps {
   variant?: 'fixed' | 'static';
@@ -11,7 +12,7 @@ export function Footer({ variant = 'fixed' }: FooterProps) {
       <div className="container py-4 md:py-0 flex flex-col md:flex-row h-auto md:h-14 items-center justify-between gap-4 md:gap-0">
         <div className="flex flex-col md:flex-row items-center md:items-center gap-2 md:gap-4">
           <p className="text-sm text-muted-foreground text-center md:text-left">
-            ResumeLM © 2025
+            ResumeLM © {new Date().getFullYear()}
           </p>
           <span className="text-sm text-muted-foreground text-center">
             Made with ❤️ in Vancouver, BC
@@ -19,7 +20,7 @@ export function Footer({ variant = 'fixed' }: FooterProps) {
         </div>
         <nav className="flex flex-col md:flex-row items-center gap-4 md:gap-6">
           <Link
-            href="mailto:resumelm@pm.me"
+            href={`mailto:${SUPPORT_EMAIL}`}
             className="flex items-center gap-1.5 text-sm text-muted-foreground hover:text-foreground transition-colors underline-offset-4 hover:underline"
           >
             <Mail className="h-4 w-4" />
@@ -27,7 +28,7 @@ export function Footer({ variant = 'fixed' }: FooterProps) {
           </Link>
           <div className="flex items-center gap-6">
             <Link
-              href="https://x.com/alexanfromvan"
+              href={CREATOR_X_URL}
               target="_blank"
               rel="noopener noreferrer"
               className="text-muted-foreground hover:text-foreground transition-colors p-1"
@@ -35,7 +36,7 @@ export function Footer({ variant = 'fixed' }: FooterProps) {
               <Twitter className="h-5 w-5 md:h-4 md:w-4" />
             </Link>
             <Link
-              href="https://linkedin.com/in/olyaiy"
+              href={CREATOR_LINKEDIN_URL}
               target="_blank"
               rel="noopener noreferrer"
               className="text-muted-foreground hover:text-foreground transition-colors p-1"
@@ -51,8 +52,14 @@ export function Footer({ variant = 'fixed' }: FooterProps) {
               <Github className="h-5 w-5 md:h-4 md:w-4" />
             </Link>
           </div>
+          <div className="flex items-center gap-4 text-sm text-muted-foreground">
+            <Link href="/privacy" className="hover:text-foreground hover:underline">Privacy</Link>
+            <Link href="/terms" className="hover:text-foreground hover:underline">Terms</Link>
+            <Link href="/refund" className="hover:text-foreground hover:underline">Refunds</Link>
+            <Link href="/security" className="hover:text-foreground hover:underline">Security</Link>
+          </div>
         </nav>
       </div>
     </footer>
   );
-} 
+}

--- a/src/components/legal/legal-page.tsx
+++ b/src/components/legal/legal-page.tsx
@@ -1,0 +1,19 @@
+import type { ReactNode } from "react";
+
+interface LegalPageProps {
+  title: string;
+  updated: string;
+  children: ReactNode;
+}
+
+export function LegalPage({ title, updated, children }: LegalPageProps) {
+  return (
+    <main className="min-h-screen bg-slate-50 px-4 py-16">
+      <article className="mx-auto max-w-3xl rounded-2xl bg-white p-8 shadow-sm md:p-12">
+        <p className="text-sm text-muted-foreground">Last updated {updated}</p>
+        <h1 className="mt-2 text-4xl font-bold tracking-tight text-gray-900">{title}</h1>
+        <div className="prose prose-slate mt-8 max-w-none">{children}</div>
+      </article>
+    </main>
+  );
+}

--- a/src/components/pricing/optimized-subscription-page.tsx
+++ b/src/components/pricing/optimized-subscription-page.tsx
@@ -7,11 +7,8 @@ import { Badge } from '@/components/ui/badge';
 import { 
   Check, 
   Clock, 
-  Users, 
-  TrendingUp, 
-  Shield, 
+  TrendingUp,
   Crown,
-  Star,
   Zap,
   ArrowRight,
   AlertCircle,
@@ -20,6 +17,7 @@ import { createPortalSession } from '@/app/(dashboard)/subscription/stripe-sessi
 import { motion } from 'framer-motion';
 import { cn } from '@/lib/utils';
 import { getSubscriptionAccessState, type SubscriptionSnapshot } from '@/lib/subscription-access';
+import { PLAN_CONFIG } from '@/lib/plans';
 
 interface Profile extends SubscriptionSnapshot {
   subscription_plan: string | null;
@@ -33,27 +31,6 @@ interface Profile extends SubscriptionSnapshot {
 interface OptimizedSubscriptionPageProps {
   initialProfile: Profile | null;
 }
-
-const testimonials = [
-  {
-    name: "Sarah Chen",
-    role: "Software Engineer at Google",
-    content: "ResumeLM helped me land 3 interviews in my first week. The AI suggestions were spot-on.",
-    avatar: "SC"
-  },
-  {
-    name: "Marcus Johnson", 
-    role: "Product Manager at Meta",
-    content: "Went from 2% to 15% response rate. This tool paid for itself with my first interview.",
-    avatar: "MJ"
-  },
-  {
-    name: "Emily Rodriguez",
-    role: "Data Scientist at Microsoft", 
-    content: "The tailored resumes feature is a game-changer. Got my dream job in 3 weeks.",
-    avatar: "ER"
-  }
-];
 
 export function OptimizedSubscriptionPage({ initialProfile }: OptimizedSubscriptionPageProps) {
   const [isLoading, setIsLoading] = useState(false);
@@ -185,7 +162,7 @@ export function OptimizedSubscriptionPage({ initialProfile }: OptimizedSubscript
               <div className="flex items-center justify-center mb-4">
                 <TrendingUp className="h-8 w-8 text-blue-500 mr-3" />
                 <Badge variant="outline" className="text-blue-700 border-blue-300 bg-blue-50">
-                  3x Higher Interview Rate
+                  Pro plan features
                 </Badge>
               </div>
               <h1 className="text-4xl md:text-5xl font-bold text-gray-900 mb-4">
@@ -219,21 +196,14 @@ export function OptimizedSubscriptionPage({ initialProfile }: OptimizedSubscript
           </motion.div>
         )}
 
-        {/* Social Proof Bar */}
+        {/* Product facts */}
         <motion.div 
           initial={{ opacity: 0, y: 20 }}
           animate={{ opacity: 1, y: 0 }}
           transition={{ delay: 0.2 }}
           className="flex items-center justify-center mb-8 text-sm text-gray-600"
         >
-          <Users className="h-4 w-4 mr-2" />
-          <span>Trusted by 12,000+ professionals</span>
-          <div className="flex ml-4">
-            {[...Array(5)].map((_, i) => (
-              <Star key={i} className="h-4 w-4 text-yellow-400 fill-current" />
-            ))}
-          </div>
-          <span className="ml-2">4.9/5 rating</span>
+          <span>Open source • $20/month • App-funded premium AI models</span>
         </motion.div>
 
         {/* Main Content Grid */}
@@ -255,20 +225,20 @@ export function OptimizedSubscriptionPage({ initialProfile }: OptimizedSubscript
                 {[
                   {
                     icon: Zap,
-                    title: "3x faster job applications",
-                    description: "AI-powered tailoring saves 15+ hours per week",
+                    title: "App-funded premium models",
+                    description: "Use Pro models without entering your own provider key",
                     highlight: true
                   },
                   {
                     icon: TrendingUp, 
-                    title: "Higher response rates",
-                    description: "Members see 300% increase in interview invitations",
+                    title: "Unlimited resume versions",
+                    description: "Create and tailor as many versions as you need",
                     highlight: true
                   },
                   {
                     icon: Crown,
-                    title: "Unlimited everything",
-                    description: "No limits on resumes, tailoring, or AI assistance"
+                    title: "Advanced AI assistance",
+                    description: "Get contextual suggestions while you edit"
                   }
                 ].map((benefit, index) => (
                   <div 
@@ -296,27 +266,6 @@ export function OptimizedSubscriptionPage({ initialProfile }: OptimizedSubscript
               </div>
             </div>
 
-            {/* Testimonials */}
-            <div className="space-y-4">
-              <h3 className="text-lg font-medium text-gray-900">Success Stories</h3>
-              <div className="space-y-4">
-                {testimonials.slice(0, 2).map((testimonial, index) => (
-                  <div key={index} className="p-4 bg-white rounded-lg shadow-sm border border-gray-200">
-                    <div className="flex items-start space-x-3">
-                      <div className="w-8 h-8 bg-gradient-to-br from-blue-500 to-purple-600 rounded-full flex items-center justify-center text-white text-xs font-medium">
-                        {testimonial.avatar}
-                      </div>
-                      <div className="flex-1">
-                        <p className="text-sm text-gray-700 mb-1">&ldquo;{testimonial.content}&rdquo;</p>
-                        <p className="text-xs text-gray-500">
-                          <strong>{testimonial.name}</strong> • {testimonial.role}
-                        </p>
-                      </div>
-                    </div>
-                  </div>
-                ))}
-              </div>
-            </div>
           </motion.div>
 
           {/* Right Column - Pricing & CTA */}
@@ -347,39 +296,21 @@ export function OptimizedSubscriptionPage({ initialProfile }: OptimizedSubscript
                 
                 {!hasProAccess && (
                   <div className="space-y-2 text-sm text-gray-600">
-                    <p>💰 <strong>Pays for itself</strong> with one interview</p>
-                    <p>⏰ Less than one lunch per month</p>
-                    <p>💼 Compare: Resume writers charge $260+</p>
+                    <p>✓ Seven-day trial</p>
+                    <p>✓ Cancel before the trial ends to avoid the recurring charge</p>
                   </div>
                 )}
               </div>
 
               {/* Feature List */}
               <div className="space-y-3 mb-8">
-                {[
-                  "Unlimited base resumes",
-                  "Unlimited AI-tailored resumes", 
-                  "Advanced AI assistance",
-                  "Premium ATS-optimized templates",
-                  "Priority customer support",
-                  "Custom branding options"
-                ].map((feature, index) => (
+                {PLAN_CONFIG.pro.features.map((feature, index) => (
                   <div key={index} className="flex items-center space-x-3">
                     <Check className="h-5 w-5 text-green-500 flex-shrink-0" />
                     <span className="text-gray-700">{feature}</span>
                   </div>
                 ))}
               </div>
-
-              {/* Risk Reduction */}
-              {!hasProAccess && (
-                <div className="flex items-center justify-center space-x-4 mb-6 p-3 bg-green-50 rounded-lg border border-green-200">
-                  <Shield className="h-5 w-5 text-green-600" />
-                  <span className="text-sm text-green-700 font-medium">
-                    30-day money-back guarantee
-                  </span>
-                </div>
-              )}
 
               {/* CTA Button */}
               <Button
@@ -401,7 +332,7 @@ export function OptimizedSubscriptionPage({ initialProfile }: OptimizedSubscript
                   isPastDue ? "Fix payment method" : "Manage Subscription"
                 ) : (
                   <div className="flex items-center justify-center space-x-2">
-                    <span>Start Landing More Interviews</span>
+                    <span>Start Pro trial</span>
                     <ArrowRight className="h-5 w-5" />
                   </div>
                 )}
@@ -413,24 +344,6 @@ export function OptimizedSubscriptionPage({ initialProfile }: OptimizedSubscript
                 </p>
               )}
             </div>
-
-            {/* Additional CTA for canceling users */}
-            {isCanceling && (
-              <div className="bg-amber-50 border border-amber-200 rounded-xl p-6">
-                <div className="text-center">
-                  <h4 className="font-semibold text-amber-900 mb-2">Limited Time Offer</h4>
-                  <p className="text-sm text-amber-700 mb-4">
-                    Reactivate now and get 2 months for the price of 1
-                  </p>
-                  <Button
-                    onClick={handleUpgrade}
-                    className="bg-amber-600 hover:bg-amber-700 text-white"
-                  >
-                    Reactivate & Save 50%
-                  </Button>
-                </div>
-              </div>
-            )}
 
 
           </motion.div>

--- a/src/components/profile/profile-edit-form.tsx
+++ b/src/components/profile/profile-edit-form.tsx
@@ -138,7 +138,7 @@ export function ProfileEditForm({ profile: initialProfile }: ProfileEditFormProp
   };
 
   const handleLinkedInImport = () => {
-    toast.info("LinkedIn import feature coming soon!", {
+    toast.info("LinkedIn import is not available yet. Upload a resume or enter your details manually.", {
       position: "bottom-right",
       className: "bg-gradient-to-r from-blue-500 to-indigo-500 text-white border-none",
     });
@@ -423,6 +423,7 @@ export function ProfileEditForm({ profile: initialProfile }: ProfileEditFormProp
                 <Button
                   variant="outline"
                   onClick={handleLinkedInImport}
+                  aria-disabled="true"
                   className="group relative bg-[#0077b5]/5 hover:bg-[#0077b5]/10 border-[#0077b5]/20 hover:border-[#0077b5]/30 text-[#0077b5] transition-all duration-500 hover:scale-[1.02] h-auto py-4"
                 >
                   <div className="absolute inset-0 bg-gradient-to-r from-[#0077b5]/0 via-[#0077b5]/5 to-[#0077b5]/0 opacity-0 group-hover:opacity-100 transition-opacity duration-500" />

--- a/src/components/settings/api-keys-form.tsx
+++ b/src/components/settings/api-keys-form.tsx
@@ -163,18 +163,18 @@ export function ApiKeysForm({ isProPlan }: { isProPlan: boolean }) {
         </Label>
         <div className="mt-2 mb-4 space-y-2">
           <p className="text-sm text-muted-foreground">
-            Add your API keys to use premium AI models. Your keys are stored securely in your browser.
+            Add your API keys to use provider models. Keys are stored in this browser&apos;s local storage.
           </p>
           <div className="p-3 rounded-lg bg-amber-50/50 border border-amber-200/50 text-amber-900 text-sm">
             {isProPlan ? (
               <>
-                <p><strong>Pro Account Active:</strong> You have full access to all AI models without needing to manage API keys.</p>
+                <p><strong>Pro Account Active:</strong> Eligible Pro requests can use app-funded models without a personal API key.</p>
                 <p className="mt-1">You can still add personal API keys below if you prefer to use your own credentials.</p>
               </>
             ) : (
               <>
-                <p><strong>Security Note:</strong> API keys are stored locally in your browser. While convenient, this means anyone with access to this device could potentially view your keys.</p>
-                <p className="mt-1">For enhanced security, consider <a href="/subscription" className="text-amber-700 hover:text-amber-800 underline underline-offset-2">upgrading to a Pro account</a> where we securely manage API access for you.</p>
+                <p><strong>Security note:</strong> API keys are stored locally in your browser and are not encrypted by ResumeLM. Anyone with access to this device or browser profile could potentially view them.</p>
+                <p className="mt-1">For app-funded model access, <a href="/subscription" className="text-amber-700 hover:text-amber-800 underline underline-offset-2">use Pro</a> instead of entering a personal key.</p>
               </>
             )}
           </div>

--- a/src/components/settings/subscription-section.tsx
+++ b/src/components/settings/subscription-section.tsx
@@ -4,10 +4,11 @@ import { useState } from 'react';
 import { useRouter } from 'next/navigation';
 import { Button } from "@/components/ui/button"
 import { Badge } from "@/components/ui/badge"
-import { Sparkles, Star, Clock, Zap, ArrowRight, Crown, Shield, Check, Users, TrendingUp, AlertCircle } from "lucide-react"
+import { Sparkles, Clock, Zap, ArrowRight, Crown, Check, TrendingUp, AlertCircle } from "lucide-react"
 import { cn } from '@/lib/utils';
 import { createPortalSession } from '@/app/(dashboard)/subscription/stripe-session';
 import { getSubscriptionAccessState, type SubscriptionSnapshot } from '@/lib/subscription-access';
+import { PLAN_CONFIG } from '@/lib/plans';
 
 interface SubscriptionSectionProps {
   initialProfile: SubscriptionSnapshot | null;
@@ -147,7 +148,7 @@ export function SubscriptionSection({ initialProfile }: SubscriptionSectionProps
               You&apos;re on the Pro plan
             </h2>
             <p className="text-gray-600 max-w-lg mx-auto">
-              Enjoying unlimited access to all premium features and priority support.
+              Enjoying unlimited resume versions and app-funded premium AI models.
             </p>
           </>
         ) : (
@@ -155,14 +156,14 @@ export function SubscriptionSection({ initialProfile }: SubscriptionSectionProps
             <div className="flex items-center justify-center mb-2">
               <TrendingUp className="h-6 w-6 text-blue-500 mr-2" />
               <Badge variant="outline" className="text-blue-700 border-blue-300 bg-blue-50">
-                3x Higher Interview Rate
+                Pro plan features
               </Badge>
             </div>
             <h2 className="text-2xl font-bold text-gray-900">
               Upgrade to ResumeLM Pro
             </h2>
             <p className="text-gray-600 max-w-lg mx-auto">
-              Join thousands of professionals landing more interviews with premium AI assistance.
+              Get unlimited resume versions and app-funded premium AI assistance for $20/month.
             </p>
           </>
         )}
@@ -184,16 +185,9 @@ export function SubscriptionSection({ initialProfile }: SubscriptionSectionProps
         </div>
       )}
 
-      {/* Social Proof */}
+      {/* Product facts */}
       <div className="flex items-center justify-center text-sm text-gray-600">
-        <Users className="h-4 w-4 mr-2" />
-        <span>Trusted by 12,000+ professionals</span>
-        <div className="flex ml-3">
-          {[...Array(5)].map((_, i) => (
-            <Star key={i} className="h-3 w-3 text-yellow-400 fill-current" />
-          ))}
-        </div>
-        <span className="ml-1">4.9/5</span>
+        <span>Open source • $20/month • App-funded premium AI models</span>
       </div>
 
       {/* Main Content */}
@@ -208,25 +202,25 @@ export function SubscriptionSection({ initialProfile }: SubscriptionSectionProps
             {[
               {
                 icon: Zap,
-                title: "3x faster applications",
-                description: "AI-powered tailoring saves hours",
+                title: "App-funded premium models",
+                description: "Use Pro models without entering your own provider key",
                 highlight: true
               },
               {
                 icon: TrendingUp, 
-                title: "Higher response rates",
-                description: "300% increase in interviews",
+                title: "Unlimited resume versions",
+                description: "Create and tailor as many versions as you need",
                 highlight: true
               },
               {
                 icon: Crown,
-                title: "Unlimited everything",
-                description: "No limits on resumes or AI"
+                title: "Advanced AI assistance",
+                description: "Get contextual suggestions while you edit"
               },
               {
                 icon: Sparkles,
-                title: "Premium templates",
-                description: "ATS-optimized designs"
+                title: "Free plan available",
+                description: "Bring your own API keys when Pro is not needed"
               }
             ].map((benefit, index) => (
               <div 
@@ -276,37 +270,21 @@ export function SubscriptionSection({ initialProfile }: SubscriptionSectionProps
               
               {!hasProAccess && (
                 <div className="space-y-1 text-xs text-gray-600">
-                  <p>💰 Pays for itself with one interview</p>
-                  <p>💼 Compare: Resume writers charge $260+</p>
+                  <p>✓ Seven-day trial</p>
+                  <p>✓ Cancel before the trial ends to avoid the recurring charge</p>
                 </div>
               )}
             </div>
 
             {/* Feature List */}
             <div className="space-y-2 mb-6">
-              {[
-                "Unlimited base resumes",
-                "Unlimited AI-tailored resumes", 
-                "Advanced AI assistance",
-                "Premium ATS templates",
-                "Priority support"
-              ].map((feature, index) => (
+              {PLAN_CONFIG.pro.features.map((feature, index) => (
                 <div key={index} className="flex items-center space-x-2">
                   <Check className="h-4 w-4 text-green-500 flex-shrink-0" />
                   <span className="text-sm text-gray-700">{feature}</span>
                 </div>
               ))}
             </div>
-
-            {/* Risk Reduction */}
-            {!hasProAccess && (
-              <div className="flex items-center justify-center space-x-2 mb-4 p-2 bg-green-50 rounded-lg border border-green-200">
-                <Shield className="h-4 w-4 text-green-600" />
-                <span className="text-xs text-green-700 font-medium">
-                  30-day money-back guarantee
-                </span>
-              </div>
-            )}
 
             {/* CTA Button */}
             <Button

--- a/src/components/ui/logo.tsx
+++ b/src/components/ui/logo.tsx
@@ -15,9 +15,10 @@ import {
 interface LogoProps {
   className?: string;
   asLink?: boolean;
+  href?: string;
 }
 
-export function Logo({ className, asLink = true }: LogoProps) {
+export function Logo({ className, asLink = true, href = "/home" }: LogoProps) {
   const logoRef = useRef<HTMLDivElement>(null);
 
   async function exportAsPNG() {
@@ -119,11 +120,11 @@ export function Logo({ className, asLink = true }: LogoProps) {
 
   if (asLink) {
     return (
-      <Link href="/home">
+      <Link href={href}>
         {logoContent}
       </Link>
     );
   }
 
   return logoContent;
-} 
+}

--- a/src/lib/auth-policy.test.ts
+++ b/src/lib/auth-policy.test.ts
@@ -1,14 +1,10 @@
 import assert from "node:assert/strict";
 import { describe, it } from "node:test";
 
-import { getEmailSignupBlockedMessage, isEmailSignupAllowed } from "./auth-policy";
+import { isEmailSignupAllowed } from "./auth-policy";
 
 describe("auth policy", () => {
-  it("requires Google for new account signup", () => {
-    assert.equal(isEmailSignupAllowed(), false);
-    assert.equal(
-      getEmailSignupBlockedMessage(),
-      "New accounts must be created with Google. Existing users can still sign in with email and password."
-    );
+  it("allows email signup", () => {
+    assert.equal(isEmailSignupAllowed(), true);
   });
 });

--- a/src/lib/auth-policy.ts
+++ b/src/lib/auth-policy.ts
@@ -1,8 +1,8 @@
 export const EMAIL_SIGNUP_BLOCKED_MESSAGE =
-  "New accounts must be created with Google. Existing users can still sign in with email and password.";
+  "Email signup is currently unavailable. You can still continue with Google.";
 
 export function isEmailSignupAllowed() {
-  return false;
+  return true;
 }
 
 export function getEmailSignupBlockedMessage() {

--- a/src/lib/plans.test.ts
+++ b/src/lib/plans.test.ts
@@ -1,0 +1,18 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+
+import { PLAN_CONFIG } from "./plans";
+
+describe("plan configuration", () => {
+  it("matches the free-plan limits shown to users", () => {
+    assert.equal(PLAN_CONFIG.free.limits.base, 2);
+    assert.equal(PLAN_CONFIG.free.limits.tailored, 5);
+    assert.ok(PLAN_CONFIG.free.features.includes("5 tailored resumes"));
+  });
+
+  it("keeps the paid offer explicit", () => {
+    assert.equal(PLAN_CONFIG.pro.price, "$20");
+    assert.equal(PLAN_CONFIG.pro.period, "/month");
+    assert.ok(PLAN_CONFIG.pro.features.includes("Access to app-funded premium AI models"));
+  });
+});

--- a/src/lib/plans.ts
+++ b/src/lib/plans.ts
@@ -1,0 +1,31 @@
+export const PLAN_CONFIG = {
+  free: {
+    name: "Free",
+    price: "$0",
+    description: "Open source resume building with your own API keys or free app-funded models",
+    limits: {
+      base: 2,
+      tailored: 5,
+    },
+    features: [
+      "Use your own API keys",
+      "2 base resumes",
+      "5 tailored resumes",
+      "Self-host option available",
+    ],
+  },
+  pro: {
+    name: "Pro",
+    price: "$20",
+    period: "/month",
+    description: "App-funded premium AI models and unlimited resume versions",
+    features: [
+      "Access to app-funded premium AI models",
+      "Unlimited base resumes",
+      "Unlimited tailored resumes",
+      "Advanced AI assistance",
+    ],
+  },
+} as const;
+
+export type PlanName = keyof typeof PLAN_CONFIG;

--- a/src/lib/resume-limits.ts
+++ b/src/lib/resume-limits.ts
@@ -1,7 +1,6 @@
-export const FREE_PLAN_RESUME_LIMITS = {
-  base: 2,
-  tailored: 4,
-} as const;
+import { PLAN_CONFIG } from "@/lib/plans";
+
+export const FREE_PLAN_RESUME_LIMITS = PLAN_CONFIG.free.limits;
 
 export type ResumeLimitType = keyof typeof FREE_PLAN_RESUME_LIMITS;
 

--- a/src/lib/site-config.test.ts
+++ b/src/lib/site-config.test.ts
@@ -1,0 +1,17 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+
+import { CREATOR_X_URL, GITHUB_REPO_URL, SITE_URL, siteUrl } from "./site-config";
+
+describe("site configuration", () => {
+  it("uses the canonical public domain and normalizes paths", () => {
+    assert.equal(SITE_URL, "https://resumelm.ca");
+    assert.equal(siteUrl("/auth/login"), "https://resumelm.ca/auth/login");
+    assert.equal(siteUrl("privacy"), "https://resumelm.ca/privacy");
+  });
+
+  it("points public links at the current project and creator profiles", () => {
+    assert.equal(GITHUB_REPO_URL, "https://github.com/olyaiy/resume-lm");
+    assert.equal(CREATOR_X_URL, "https://x.com/alexfromvan");
+  });
+});

--- a/src/lib/site-config.ts
+++ b/src/lib/site-config.ts
@@ -1,0 +1,11 @@
+export const SITE_URL = (process.env.NEXT_PUBLIC_SITE_URL || "https://resumelm.ca").replace(/\/+$/, "");
+
+export const GITHUB_REPO_URL = "https://github.com/olyaiy/resume-lm";
+export const CREATOR_X_URL = "https://x.com/alexfromvan";
+export const CREATOR_LINKEDIN_URL = "https://linkedin.com/in/olyaiy";
+export const SUPPORT_EMAIL = "resumelm@pm.me";
+
+export function siteUrl(path = "") {
+  if (!path) return SITE_URL;
+  return `${SITE_URL}/${path.replace(/^\/+/, "")}`;
+}

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,7 +1,21 @@
-import { type NextRequest } from 'next/server'
+import { NextResponse, type NextRequest } from 'next/server'
 import { updateSession } from '@/utils/supabase/middleware'
+import { SITE_URL } from '@/lib/site-config'
 
 export async function middleware(request: NextRequest) {
+  const hostname = request.nextUrl.hostname.toLowerCase()
+  const canonicalHostname = new URL(SITE_URL).hostname.toLowerCase()
+
+  if (
+    hostname !== canonicalHostname &&
+    (hostname === 'resumelm.com' || hostname === 'www.resumelm.com')
+  ) {
+    const canonicalUrl = request.nextUrl.clone()
+    canonicalUrl.protocol = 'https:'
+    canonicalUrl.hostname = canonicalHostname
+    return NextResponse.redirect(canonicalUrl, 308)
+  }
+
   console.log('🧩 Root middleware invoked for:', request.nextUrl.pathname)
   return await updateSession(request)
 }
@@ -15,9 +29,9 @@ export const config = {
      * - favicon.ico (favicon file)
      * - api/webhooks (webhook endpoints)
      * - blog (blog section)
-     * - image files (svg, png, jpg, etc.)
+     * - public metadata and media files
      * Run on all other routes to protect them
      */
-    '/((?!_next/static|_next/image|favicon.ico|api/webhooks|blog(?:/.*)?|.*\\.(?:svg|png|jpg|jpeg|gif|webp)$).*)',
+    '/((?!_next/static|_next/image|favicon.ico|robots.txt|sitemap.xml|api/webhooks|blog(?:/.*)?|.*\\.(?:svg|png|jpg|jpeg|gif|webp|mp4|webm|mov|m4v|ogv)$).*)',
   ],
 }

--- a/src/utils/supabase/middleware.ts
+++ b/src/utils/supabase/middleware.ts
@@ -10,6 +10,7 @@ const SUBSCRIPTION_EXEMPT_ROUTES = [
   '/settings',
   '/subscription',
   '/start-trial',
+  '/jobs',
   '/subscription/checkout',
   '/subscription/checkout-return',
   '/auth',

--- a/supabase/migrations/20260801090000_harden_public_function_search_paths.sql
+++ b/supabase/migrations/20260801090000_harden_public_function_search_paths.sql
@@ -1,0 +1,39 @@
+-- Keep SECURITY DEFINER and shared helper functions on an explicit search path.
+-- This prevents caller-controlled schemas from changing object resolution.
+ALTER FUNCTION public.get_profiles_for_users(uuid[])
+  SET search_path = public, pg_temp;
+
+ALTER FUNCTION public.get_subscriptions_for_users(uuid[])
+  SET search_path = public, pg_temp;
+
+ALTER FUNCTION public.get_resume_counts_for_users(uuid[])
+  SET search_path = public, pg_temp;
+
+ALTER FUNCTION public.count_resumes_by_user(uuid[])
+  SET search_path = public, pg_temp;
+
+ALTER FUNCTION public.count_total_resumes()
+  SET search_path = public, pg_temp;
+
+ALTER FUNCTION public.count_total_users()
+  SET search_path = public, pg_temp;
+
+ALTER FUNCTION public.trigger_set_timestamp()
+  SET search_path = public, pg_temp;
+
+ALTER FUNCTION public.update_updated_at_column()
+  SET search_path = public, pg_temp;
+
+ALTER FUNCTION public.handle_new_user()
+  SET search_path = public, pg_temp;
+
+-- This function is SECURITY DEFINER and should only be callable by the auth
+-- service if a deployment uses it as an auth hook. It must not be public.
+REVOKE EXECUTE ON FUNCTION public.handle_new_user() FROM PUBLIC, anon, authenticated;
+DO $$
+BEGIN
+  IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'supabase_auth_admin') THEN
+    GRANT EXECUTE ON FUNCTION public.handle_new_user() TO supabase_auth_admin;
+  END IF;
+END
+$$;


### PR DESCRIPTION
## What changed

- Restore email signup in the auth dialog alongside Google sign-in.
- Preserve `next`/plan intent through password login, Google OAuth, and email confirmation.
- Add structured auth logging and clearer sign-in error messages.
- Canonicalize `.com` traffic to `resumelm.ca`, exempt media from auth middleware, and fix stale repo/asset/social links.
- Align plan limits and pricing copy with the actual product; remove unsupported social proof, outcome guarantees, fake testimonials, and unavailable feature promises.
- Add factual privacy, terms, refund, security, robots, and sitemap pages.
- Add missing routes for existing navigation links and a Supabase migration that hardens function search paths and locks down the unused auth hook.
- Add public-contract checks and regression tests.

## Validation

- `node scripts/check-public-contracts.mjs`
- `node node_modules/.pnpm/tsx@4.19.4/node_modules/tsx/dist/cli.mjs --test "src/**/*.test.ts"` (75 passing)
- `node_modules/.bin/tsc --noEmit --pretty false`
- `STRIPE_SECRET_KEY=sk_test_51dummy NEXT_PUBLIC_SUPABASE_URL=https://example.supabase.co NEXT_PUBLIC_SUPABASE_ANON_KEY=eyJdummy NEXT_PUBLIC_SITE_URL=https://resumelm.ca node_modules/.bin/next build`

The build emits the existing OpenTelemetry dynamic-require warning and local Upstash config warnings, but completes successfully.
