### PR TITLE
fix: allow public legal pages

### DIFF
--- a/src/utils/supabase/middleware.ts
+++ b/src/utils/supabase/middleware.ts
@@ -72,7 +72,11 @@ export async function updateSession(request: NextRequest) {
     const isPublicRoute =
       pathname === '/' ||
       pathname.startsWith('/auth') ||
-      pathname.startsWith('/blog')
+      pathname.startsWith('/blog') ||
+      pathname === '/privacy' ||
+      pathname === '/terms' ||
+      pathname === '/refund' ||
+      pathname === '/security'
 
     if (isPublicRoute) {
       console.log('✅ Allowing unauthenticated access to public route:', pathname)


### PR DESCRIPTION
The new privacy, terms, refund, and security pages must be reachable without authentication. Add them to the middleware public-route allowlist. Validated with TypeScript and live reproduction from the merged deployment.