### PR TITLE
Split editor bundle by interaction and tab

### DIFF
--- a/src/components/resume/assistant/suggestions.tsx
+++ b/src/components/resume/assistant/suggestions.tsx
@@ -6,7 +6,7 @@ import { Card } from "@/components/ui/card";
 import { Check, X, Sparkles } from "lucide-react";
 import { WorkExperience, Project, Skill, Education } from "@/lib/types";
 import { useState } from 'react';
-import Tiptap from "@/components/ui/tiptap";
+import Tiptap from "@/components/ui/lazy-tiptap";
 
 const DIFF_HIGHLIGHT_CLASSES = "bg-green-300 px-1  rounded-sm";
 

--- a/src/components/resume/editor/forms/education-form.tsx
+++ b/src/components/resume/editor/forms/education-form.tsx
@@ -9,7 +9,7 @@ import { Plus, Trash2, ChevronUp, ChevronDown } from "lucide-react";
 import { ImportFromProfileDialog } from "../../management/dialogs/import-from-profile-dialog";
 import { memo } from 'react';
 import { cn } from "@/lib/utils";
-import Tiptap from "@/components/ui/tiptap";
+import Tiptap from "@/components/ui/lazy-tiptap";
 
 
 interface EducationFormProps {
@@ -316,4 +316,4 @@ export const EducationForm = memo(function EducationFormComponent({
       ))}
     </div>
   );
-}, areEducationPropsEqual); 
+}, areEducationPropsEqual);

--- a/src/components/resume/editor/forms/projects-form.tsx
+++ b/src/components/resume/editor/forms/projects-form.tsx
@@ -19,7 +19,7 @@ import { AISuggestions } from "../../shared/ai-suggestions";
 import { generateProjectPoints, improveProject } from "@/utils/actions/resumes/ai";
 import { Badge } from "@/components/ui/badge";
 import { KeyboardEvent } from "react";
-import Tiptap from "@/components/ui/tiptap";
+import Tiptap from "@/components/ui/lazy-tiptap";
 import { AIImprovementPrompt } from "../../shared/ai-improvement-prompt";
 import { AIGenerationSettingsTooltip } from "../components/ai-generation-tooltip";
 import { ApiErrorDialog } from "@/components/ui/api-error-dialog";

--- a/src/components/resume/editor/forms/work-experience-form.tsx
+++ b/src/components/resume/editor/forms/work-experience-form.tsx
@@ -17,7 +17,7 @@ import {
   TooltipTrigger,
   TooltipProvider,
 } from "@/components/ui/tooltip";
-import Tiptap from "@/components/ui/tiptap";
+import Tiptap from "@/components/ui/lazy-tiptap";
 import { generateWorkExperiencePoints, improveWorkExperience } from "@/utils/actions/resumes/ai";
 import { AIImprovementPrompt } from "../../shared/ai-improvement-prompt";
 import { AIGenerationSettingsTooltip } from "../components/ai-generation-tooltip";

--- a/src/components/resume/editor/panels/editor-panel.tsx
+++ b/src/components/resume/editor/panels/editor-panel.tsx
@@ -2,15 +2,11 @@
 
 import { Resume, Profile, Job, DocumentSettings } from "@/lib/types";
 import { ScrollArea } from "@/components/ui/scroll-area";
-import { Accordion } from "@/components/ui/accordion";
 import { Tabs, TabsContent } from "@/components/ui/tabs";
 import { Suspense, useRef } from "react";
 import { cn } from "@/lib/utils";
 import { ResumeEditorActions } from "../actions/resume-editor-actions";
-import { TailoredJobAccordion } from "../../management/cards/tailored-job-card";
 import { BasicInfoForm } from "../forms/basic-info-form";
-import ChatBot from "../../assistant/chatbot";
-import { CoverLetterPanel } from "./cover-letter-panel";
 import {
   WorkExperienceForm,
   EducationForm,
@@ -19,7 +15,12 @@ import {
   DocumentSettingsForm
 } from '../dynamic-components';
 import { ResumeEditorTabs } from "../header/resume-editor-tabs";
-import ResumeScorePanel from "./resume-score-panel";
+import {
+  ChatAssistantSlot,
+  LazyCoverLetterPanel,
+  LazyResumeScorePanel,
+  LazyTailoredJobAccordion,
+} from "./lazy-editor-features";
 
 
 
@@ -60,13 +61,11 @@ export function EditorPanel({
 
 
             {/* Tailored Job Accordion */}
-            <Accordion type="single" collapsible defaultValue="basic" className="mt-6">
-              <TailoredJobAccordion
-                resume={resume}
-                job={job}
-                isLoading={isLoadingJob}
-              />
-            </Accordion>
+            <LazyTailoredJobAccordion
+              resume={resume}
+              job={job}
+              isLoading={isLoadingJob}
+            />
 
             {/* Tabs */}  
             <Tabs defaultValue="basic" className="mb-4">
@@ -164,7 +163,7 @@ export function EditorPanel({
 
               {/* Cover Letter Form */}
               <TabsContent value="cover-letter">
-                <CoverLetterPanel
+                <LazyCoverLetterPanel
                   resume={resume}
                   job={job}
                 />
@@ -173,7 +172,7 @@ export function EditorPanel({
 
               {/* Resume Score Form */}
               <TabsContent value="resume-score">
-                <ResumeScorePanel
+                <LazyResumeScorePanel
                   resume={resume}
                   job={job}
                 />
@@ -189,7 +188,7 @@ export function EditorPanel({
           ? "bg-purple-50/50 border-purple-200/40"
           : "bg-pink-50/80 border-pink-300/50 shadow-sm shadow-pink-200/20"
       )}>
-        <ChatBot 
+        <ChatAssistantSlot
           resume={resume} 
           onResumeChange={onResumeChange}
           job={job}

--- a/src/components/resume/editor/panels/lazy-editor-features.tsx
+++ b/src/components/resume/editor/panels/lazy-editor-features.tsx
@@ -1,0 +1,124 @@
+"use client";
+
+import dynamic from "next/dynamic";
+import { useState, type ComponentType } from "react";
+import { Bot, BriefcaseIcon } from "lucide-react";
+import { Accordion, AccordionContent, AccordionItem, AccordionTrigger } from "@/components/ui/accordion";
+import { cn } from "@/lib/utils";
+import type { Job, Resume } from "@/lib/types";
+import { LoadingFallback } from "../shared/LoadingFallback";
+
+const LazyChatBot = dynamic(
+  () => import("../../assistant/chatbot"),
+  {
+    ssr: false,
+    loading: () => <LoadingFallback lines={2} />,
+  },
+);
+
+export const LazyCoverLetterPanel = dynamic(
+  () => import("./cover-letter-panel").then((module) => ({ default: module.CoverLetterPanel })),
+  {
+    ssr: false,
+    loading: () => <LoadingFallback lines={3} />,
+  },
+);
+
+export const LazyResumeScorePanel = dynamic(
+  () => import("./resume-score-panel"),
+  {
+    ssr: false,
+    loading: () => <LoadingFallback lines={3} />,
+  },
+);
+
+interface ChatAssistantSlotProps {
+  resume: Resume;
+  onResumeChange: (field: keyof Resume, value: Resume[keyof Resume]) => void;
+  job?: Job | null;
+}
+
+export function ChatAssistantSlot({ resume, onResumeChange, job }: ChatAssistantSlotProps) {
+  const [isOpen, setIsOpen] = useState(false);
+
+  if (!isOpen) {
+    return (
+      <button
+        type="button"
+        onClick={() => setIsOpen(true)}
+        className={cn(
+          "flex w-full items-center justify-center gap-2 rounded-lg border-2 px-3 py-2",
+          "border-purple-200/60 bg-purple-50/70 text-xs font-medium text-purple-700",
+          "shadow-sm transition-colors hover:border-purple-300/70 hover:bg-purple-100/80",
+        )}
+        aria-label="Open ResumeLM AI assistant"
+      >
+        <Bot className="h-3.5 w-3.5" />
+        Open AI assistant
+      </button>
+    );
+  }
+
+  return <LazyChatBot resume={resume} onResumeChange={onResumeChange} job={job} />;
+}
+
+interface TailoredJobAccordionProps {
+  resume: Resume;
+  job: Job | null;
+  isLoading?: boolean;
+}
+
+type LoadedJobAccordion = ComponentType<TailoredJobAccordionProps>;
+
+export function LazyTailoredJobAccordion({ resume, job, isLoading }: TailoredJobAccordionProps) {
+  const [value, setValue] = useState<string | undefined>();
+  const [LoadedAccordion, setLoadedAccordion] = useState<LoadedJobAccordion | null>(null);
+
+  if (resume.is_base_resume) return null;
+
+  const title = job?.position_title || "Target Job";
+  const company = job?.company_name;
+
+  const handleValueChange = (nextValue: string) => {
+    setValue(nextValue || undefined);
+
+    if (nextValue !== "job" || LoadedAccordion) return;
+
+    void import("../../management/cards/tailored-job-card").then(({ TailoredJobAccordion }) => {
+      setLoadedAccordion(() => TailoredJobAccordion);
+    });
+  };
+
+  return (
+    <Accordion
+      type="single"
+      collapsible
+      value={value}
+      onValueChange={handleValueChange}
+      className="mt-6"
+    >
+      {LoadedAccordion ? (
+        <LoadedAccordion resume={resume} job={job} isLoading={isLoading} />
+      ) : (
+        <AccordionItem value="job" className="mb-4 rounded-lg border-2 border-pink-600/50 bg-white shadow-lg backdrop-blur-xl">
+          <div className="px-4">
+            <AccordionTrigger className="group hover:no-underline">
+              <div className="flex items-center gap-2">
+                <div className="rounded-md bg-pink-100/80 p-1 transition-transform duration-300 group-data-[state=open]:scale-105">
+                  <BriefcaseIcon className="h-3.5 w-3.5 text-pink-600" />
+                </div>
+                <div className="flex flex-col items-start">
+                  <span className="text-sm font-medium text-pink-900">{title}</span>
+                  {company && <span className="text-xs text-pink-600/80">{company}</span>}
+                </div>
+              </div>
+            </AccordionTrigger>
+          </div>
+          <AccordionContent>
+            <LoadingFallback lines={3} />
+          </AccordionContent>
+        </AccordionItem>
+      )}
+    </Accordion>
+  );
+}

--- a/src/components/resume/editor/panels/preview-panel.tsx
+++ b/src/components/resume/editor/panels/preview-panel.tsx
@@ -1,11 +1,19 @@
 'use client';
 
+import dynamic from "next/dynamic";
 import { Resume } from "@/lib/types";
 import { ScrollArea } from "@/components/ui/scroll-area";
 import { cn } from "@/lib/utils";
 import { ResumePreview } from "../preview/resume-preview";
-import CoverLetter from "@/components/cover-letter/cover-letter";
 import { ResumeContextMenu } from "../preview/resume-context-menu";
+import { Button } from "@/components/ui/button";
+import { Plus } from "lucide-react";
+import { LoadingFallback } from "../shared/LoadingFallback";
+
+const LazyCoverLetter = dynamic(() => import("@/components/cover-letter/cover-letter"), {
+  ssr: false,
+  loading: () => <LoadingFallback lines={3} />,
+});
 
 interface PreviewPanelProps {
   resume: Resume;
@@ -16,7 +24,7 @@ interface PreviewPanelProps {
 
 export function PreviewPanel({
   resume,
-  // onResumeChange,
+  onResumeChange,
   width
 }: PreviewPanelProps) {
   return (
@@ -32,20 +40,21 @@ export function PreviewPanel({
         </ResumeContextMenu>
       </div>
 
-      <CoverLetter 
-        // resumeId={resume.id} 
-        // hasCoverLetter={resume.has_cover_letter}
-        // coverLetterData={resume.cover_letter}
-        containerWidth={width}
-        // onCoverLetterChange={(data: Record<string, unknown>) => {
-        //   if ('has_cover_letter' in data) {
-        //     onResumeChange('has_cover_letter', data.has_cover_letter as boolean);
-        //   }
-        //   if ('cover_letter' in data) {    
-        //     onResumeChange('cover_letter', data.cover_letter as Record<string, unknown>);
-        //   }
-        // }}
-      />
+      {resume.has_cover_letter ? (
+        <LazyCoverLetter containerWidth={width} />
+      ) : (
+        <div className="p-4">
+          <Button
+            variant="outline"
+            size="sm"
+            className="w-full border-emerald-600/50 text-emerald-700 hover:bg-emerald-50"
+            onClick={() => onResumeChange("has_cover_letter", true)}
+          >
+            <Plus className="mr-2 h-4 w-4" />
+            Create Cover Letter
+          </Button>
+        </div>
+      )}
     </ScrollArea>
   );
 } 

--- a/src/components/resume/management/dialogs/text-import-dialog.tsx
+++ b/src/components/resume/management/dialogs/text-import-dialog.tsx
@@ -16,19 +16,31 @@ import { ProUpgradeButton } from "@/components/settings/pro-upgrade-button";
 interface TextImportDialogProps {
   resume: Resume;
   onResumeChange: (field: keyof Resume, value: Resume[keyof Resume]) => void;
-  trigger: React.ReactNode;
+  trigger?: React.ReactNode;
+  open?: boolean;
+  onOpenChange?: (open: boolean) => void;
 }
 
 export function TextImportDialog({
   resume,
   onResumeChange,
-  trigger
+  trigger,
+  open: controlledOpen,
+  onOpenChange: controlledOnOpenChange,
 }: TextImportDialogProps) {
-  const [open, setOpen] = useState(false);
+  const [internalOpen, setInternalOpen] = useState(false);
+  const open = controlledOpen ?? internalOpen;
   const [content, setContent] = useState("");
   const [isProcessing, setIsProcessing] = useState(false);
   const [isDragging, setIsDragging] = useState(false);
   const [apiKeyError, setApiKeyError] = useState("");
+
+  const handleOpenChange = (nextOpen: boolean) => {
+    if (controlledOpen === undefined) {
+      setInternalOpen(nextOpen);
+    }
+    controlledOnOpenChange?.(nextOpen);
+  };
 
   useEffect(() => {
     if (!open) {
@@ -116,7 +128,7 @@ export function TextImportDialog({
         title: "Import successful",
         description: "Your resume has been updated with the imported content.",
       });
-      setOpen(false);
+      handleOpenChange(false);
       setContent("");
     } catch (error) {
       console.error('Import error:', error);
@@ -138,10 +150,8 @@ export function TextImportDialog({
   };
 
   return (
-    <Dialog open={open} onOpenChange={setOpen}>
-      <DialogTrigger asChild>
-        {trigger}
-      </DialogTrigger>
+    <Dialog open={open} onOpenChange={handleOpenChange}>
+      {trigger && <DialogTrigger asChild>{trigger}</DialogTrigger>}
       <DialogContent className="sm:max-w-[600px] bg-white/95 backdrop-blur-xl border-white/40 shadow-2xl">
         <DialogHeader>
           <DialogTitle className="text-2xl bg-gradient-to-r from-violet-600 to-indigo-600 bg-clip-text text-transparent">
@@ -226,7 +236,7 @@ export function TextImportDialog({
         <DialogFooter>
           <Button
             variant="outline"
-            onClick={() => setOpen(false)}
+            onClick={() => handleOpenChange(false)}
             className="border-gray-200"
           >
             Cancel
@@ -249,4 +259,4 @@ export function TextImportDialog({
       </DialogContent>
     </Dialog>
   );
-} 
+}

--- a/src/components/resume/shared/ai-suggestions.tsx
+++ b/src/components/resume/shared/ai-suggestions.tsx
@@ -3,7 +3,7 @@
 import { cn } from "@/lib/utils";
 import { Button } from "@/components/ui/button";
 import { Check, Sparkles, X } from "lucide-react";
-import Tiptap from "@/components/ui/tiptap";
+import Tiptap from "@/components/ui/lazy-tiptap";
 
 interface AISuggestion {
   id: string;
@@ -118,4 +118,4 @@ export function AISuggestions({ suggestions, onApprove, onDelete }: AISuggestion
       </div>
     </div>
   );
-} 
+}

--- a/src/components/resume/shared/description-point.tsx
+++ b/src/components/resume/shared/description-point.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import Tiptap from "@/components/ui/tiptap";
+import Tiptap from "@/components/ui/lazy-tiptap";
 import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
 import { Sparkles, Loader2, Trash2, Check, X } from "lucide-react";
@@ -180,4 +180,4 @@ export function DescriptionPoint({
       </div>
     </div>
   );
-} 
+}

--- a/src/components/resume/text-import.tsx
+++ b/src/components/resume/text-import.tsx
@@ -1,9 +1,9 @@
 'use client';
 
+import { useState, type ComponentType, type ReactNode } from "react";
 import { Button } from "@/components/ui/button";
 import { FileText } from "lucide-react";
 import { Resume } from "@/lib/types";
-import { TextImportDialog } from "./management/dialogs/text-import-dialog";
 
 
 interface TextImportProps {
@@ -12,25 +12,52 @@ interface TextImportProps {
   className?: string;
 }
 
+interface LazyTextImportDialogProps {
+  resume: Resume;
+  onResumeChange: (field: keyof Resume, value: Resume[keyof Resume]) => void;
+  trigger?: ReactNode;
+  open?: boolean;
+  onOpenChange?: (open: boolean) => void;
+}
+
 export function TextImport({
   resume,
   onResumeChange,
   className
 }: TextImportProps) {
+  const [isOpen, setIsOpen] = useState(false);
+  const [DialogComponent, setDialogComponent] = useState<ComponentType<LazyTextImportDialogProps> | null>(null);
+
+  const handleOpen = () => {
+    setIsOpen(true);
+    if (DialogComponent) return;
+
+    void import("./management/dialogs/text-import-dialog").then(({ TextImportDialog }) => {
+      setDialogComponent(() => TextImportDialog);
+    });
+  };
+
+  const trigger = (
+    <Button
+      size="sm"
+      className={className}
+      onClick={handleOpen}
+    >
+      <div className="absolute inset-0 bg-[linear-gradient(to_right,transparent_0%,#ffffff20_50%,transparent_100%)] translate-x-[-100%] group-hover:translate-x-[100%] transition-transform duration-1000" />
+      <FileText className="mr-2 h-4 w-4" />
+      Import
+    </Button>
+  );
+
+  if (!DialogComponent) return trigger;
+
   return (
-    <TextImportDialog
+    <DialogComponent
       resume={resume}
       onResumeChange={onResumeChange}
-      trigger={
-        <Button
-          size="sm"
-          className={className}
-        >
-          <div className="absolute inset-0 bg-[linear-gradient(to_right,transparent_0%,#ffffff20_50%,transparent_100%)] translate-x-[-100%] group-hover:translate-x-[100%] transition-transform duration-1000" />
-          <FileText className="mr-2 h-4 w-4" />
-          Import
-        </Button>
-      }
+      open={isOpen}
+      onOpenChange={setIsOpen}
+      trigger={trigger}
     />
   );
-} 
+}

--- a/src/components/ui/lazy-tiptap.tsx
+++ b/src/components/ui/lazy-tiptap.tsx
@@ -1,0 +1,9 @@
+"use client";
+
+import dynamic from "next/dynamic";
+
+const LazyTiptap = dynamic(() => import("./tiptap"), {
+  ssr: false,
+});
+
+export default LazyTiptap;

--- a/src/components/ui/tiptap.tsx
+++ b/src/components/ui/tiptap.tsx
@@ -11,7 +11,7 @@ import History from '@tiptap/extension-history'
 import { memo } from 'react'
 import { cn } from '@/lib/utils'
 
-interface TiptapProps {
+export interface TiptapProps {
   content: string;
   onChange: (content: string) => void;
   className?: string;


### PR DESCRIPTION
## What changed

- Keep the editor hot path limited to basic resume state, active editing form, lightweight preview, and save status.
- Lazy-load the AI assistant until opened.
- Lazy-load tailored-job details until expanded.
- Lazy-load cover-letter and resume-score panels behind their tabs.
- Keep cover-letter TipTap code out of resumes without a cover letter.
- Lazy-load TipTap inside rich-text forms and defer PDF/text-import dependencies until used.

## Verification

- `pnpm typecheck`
- `pnpm lint`
- `pnpm test` (75 passing)
- `pnpm build`
- Local `/editor-test` route returned 200 with the actual editor and lightweight controls.
- Production route initial client chunks contain no TipTap/ProseMirror, PDF renderer, chat stick-to-bottom, score progress-bar, or animation signatures.