### PR TITLE
Fix legacy AI model traffic and terminal retries

### DIFF
--- a/scripts/check-public-contracts.mjs
+++ b/scripts/check-public-contracts.mjs
@@ -5,7 +5,7 @@ import { join } from "node:path";
 const root = process.cwd();
 const publicSources = [
   "README.md",
-  "src/app/page.tsx",
+  "src/app/(marketing)/page.tsx",
   "src/components/landing/Hero.tsx",
   "src/components/landing/FeatureHighlights.tsx",
   "src/components/landing/PricingPlans.tsx",
@@ -39,7 +39,14 @@ for (const relativePath of publicSources) {
 
 assert.equal(existsSync(join(root, "public/ResumeLM.mp4")), true);
 assert.equal(existsSync(join(root, "public/logos/deepseek-logo-full.png")), true);
-for (const route of ["privacy", "terms", "refund", "security", "robots.ts", "sitemap.ts"]) {
+for (const route of [
+  "(marketing)/privacy",
+  "(marketing)/terms",
+  "(marketing)/refund",
+  "(marketing)/security",
+  "robots.ts",
+  "sitemap.ts",
+]) {
   assert.equal(existsSync(join(root, `src/app/${route}`)), true, `missing public route ${route}`);
 }
 

--- a/src/app/(dashboard)/settings/actions.ts
+++ b/src/app/(dashboard)/settings/actions.ts
@@ -2,8 +2,10 @@
 
 import { createClient } from "@/utils/supabase/server";
 import { revalidatePath } from "next/cache";
-import OpenAI from "openai";
+import { generateText } from "ai";
 import { MODEL_DESIGNATIONS } from '@/lib/ai-models';
+import { createAIClientFromResolvedRequest } from '@/utils/ai-tools';
+import { assertProviderCircuitClosed } from '@/lib/ai/reliability';
 
 interface SecurityResult {
   success: boolean;
@@ -17,7 +19,7 @@ export async function updateEmail(formData: FormData): Promise<SecurityResult> {
 
   // First verify the current user
   const { data: { user }, error: userError } = await supabase.auth.getUser();
-  
+
   if (userError || !user?.email) {
     return { success: false, error: 'Unable to verify current user' };
   }
@@ -93,37 +95,46 @@ interface ApiTestResult {
     try {
       const supabase = await createClient()
       
-      // Get the API key from vault
+      // Get the OpenRouter API key from the server-side vault. The old
+      // implementation queried OpenAI and sent an OpenRouter model ID to the
+      // direct OpenAI SDK, which created legacy traffic and guaranteed failure.
       const { data: apiKey, error: keyError } = await supabase
         .rpc('get_api_key', {
-          p_service_name: 'openai'
+          p_service_name: 'openrouter'
         })
   
-      if (keyError || !apiKey) {
+      if (keyError || !apiKey?.trim()) {
         return { 
           success: false, 
-          error: 'No API key found for OpenAI' 
+          error: 'No API key found for OpenRouter'
         }
       }
-  
-      const openai = new OpenAI({
-        apiKey: apiKey.trim(),
+
+      const normalizedApiKey = apiKey.trim();
+      await assertProviderCircuitClosed({
+        providerId: 'openrouter',
+        modelId: MODEL_DESIGNATIONS.FAST_CHEAP_FREE,
+        apiKey: normalizedApiKey,
+        usedServerKey: false,
       });
-  
-      const response = await openai.chat.completions.create({
-        model: MODEL_DESIGNATIONS.FAST_CHEAP_FREE,
-        messages: [{ role: 'user', content: 'Say this is a test!' }],
-        response_format: { type: "text" },
-        temperature: 1,
-        max_tokens: 8000,
-        top_p: 1,
-        frequency_penalty: 0,
-        presence_penalty: 0
+
+      const model = createAIClientFromResolvedRequest({
+        providerId: 'openrouter',
+        modelId: MODEL_DESIGNATIONS.FAST_CHEAP_FREE,
+        apiKey: normalizedApiKey,
+        usedServerKey: false,
+        requiresRateLimit: false,
+      });
+
+      const response = await generateText({
+        model,
+        prompt: 'Say this is a test!',
+        maxRetries: 0,
       });
   
       return {
         success: true,
-        message: response.choices[0]?.message?.content || 'API connection successful'
+        message: response.text || 'API connection successful'
       }
   
     } catch (error) {
@@ -134,5 +145,3 @@ interface ApiTestResult {
       }
     }
   }
-  
-  

--- a/src/app/api/ai/model-health/route.ts
+++ b/src/app/api/ai/model-health/route.ts
@@ -1,0 +1,17 @@
+import { NextResponse } from "next/server";
+
+import { getCanonicalModelId, getDefaultModel } from "@/lib/ai-models";
+import { getModelHealth } from "@/lib/ai/reliability";
+
+export async function GET(request: Request) {
+  const { searchParams } = new URL(request.url);
+  const requestedModel = searchParams.get("model")?.trim();
+  const modelId = getCanonicalModelId(requestedModel || getDefaultModel(false));
+  const health = await getModelHealth(modelId);
+
+  return NextResponse.json(health, {
+    headers: {
+      "Cache-Control": "private, max-age=10, stale-while-revalidate=30",
+    },
+  });
+}

--- a/src/app/api/chat/route.ts
+++ b/src/app/api/chat/route.ts
@@ -136,6 +136,7 @@ export async function POST(req: Request) {
     // Build and send the AI call.
     const result = streamText({
       model: aiClient as LanguageModelV1,
+      maxRetries: 0,
       ...(providerOptions ? { providerOptions } : {}),
       system: systemPrompt,
       messages,
@@ -180,6 +181,7 @@ export async function POST(req: Request) {
       return new Response(
         JSON.stringify({
           error: error.message,
+          ...(error.fallbackModelId ? { fallbackModelId: error.fallbackModelId } : {}),
           ...(retryAfter ? { expirationTimestamp: Date.now() + retryAfter * 1000 } : {}),
         }),
         {

--- a/src/components/profile/profile-edit-form.tsx
+++ b/src/components/profile/profile-edit-form.tsx
@@ -33,7 +33,7 @@ import { AlertDialog, AlertDialogAction, AlertDialogCancel, AlertDialogContent, 
 import { ProUpgradeButton } from "@/components/settings/pro-upgrade-button";
 import { AlertTriangle } from "lucide-react";
 import { importResume, updateProfile } from "@/utils/actions/profiles/actions";
-import { getCanonicalModelId, MODEL_DESIGNATIONS } from "@/lib/ai-models";
+import { getStoredModelSelection, MODEL_DESIGNATIONS } from "@/lib/ai-models";
 import { cn, withBasePath } from "@/lib/utils";
 import pdfToText from "react-pdftotext";
 
@@ -149,12 +149,9 @@ export function ProfileEditForm({ profile: initialProfile }: ProfileEditFormProp
       setIsProcessingResume(true);
       
       // Get model and API key from local storage
-      const MODEL_STORAGE_KEY = 'resumelm-default-model';
       const LOCAL_STORAGE_KEY = 'resumelm-api-keys';
       
-      const selectedModel = getCanonicalModelId(
-        localStorage.getItem(MODEL_STORAGE_KEY) || MODEL_DESIGNATIONS.DEFAULT_FREE
-      );
+      const selectedModel = getStoredModelSelection(MODEL_DESIGNATIONS.DEFAULT_FREE);
       const storedKeys = localStorage.getItem(LOCAL_STORAGE_KEY);
       let apiKeys = [];
       

--- a/src/components/resume/assistant/chatbot.tsx
+++ b/src/components/resume/assistant/chatbot.tsx
@@ -36,6 +36,7 @@ import { ApiKeyErrorAlert } from '@/components/ui/api-key-error-alert';
 import { Textarea } from '@/components/ui/textarea';
 import { useApiKeys, useDefaultModel } from '@/hooks/use-api-keys';
 import { useCustomPrompts } from '@/hooks/use-custom-prompts';
+import { MODEL_DESIGNATIONS } from '@/lib/ai-models';
 
 interface ChatBotProps {
   resume: Resume;
@@ -71,7 +72,7 @@ export default function ChatBot({ resume, onResumeChange, job }: ChatBotProps) {
   
   // Use synchronized hooks for instant updates when settings change
   const { apiKeys } = useApiKeys();
-  const { defaultModel } = useDefaultModel();
+  const { defaultModel, setDefaultModel } = useDefaultModel();
   const { customPrompts } = useCustomPrompts();
   
   const [originalResume, setOriginalResume] = React.useState<Resume | null>(null);
@@ -99,7 +100,13 @@ export default function ChatBot({ resume, onResumeChange, job }: ChatBotProps) {
  
       setIsInitialLoading(false);
     },
-    onError() {
+    onError(chatError) {
+      if (
+        chatError instanceof Error &&
+        /model is unavailable|unknown model|invalid model/i.test(chatError.message)
+      ) {
+        setDefaultModel(MODEL_DESIGNATIONS.FAST_CHEAP_FREE);
+      }
       setIsInitialLoading(false);
     },
     async onToolCall({ toolCall }) {

--- a/src/components/resume/editor/forms/projects-form.tsx
+++ b/src/components/resume/editor/forms/projects-form.tsx
@@ -20,6 +20,7 @@ import { generateProjectPoints, improveProject } from "@/utils/actions/resumes/a
 import { Badge } from "@/components/ui/badge";
 import { KeyboardEvent } from "react";
 import Tiptap from "@/components/ui/lazy-tiptap";
+import { getStoredModelSelection } from "@/lib/ai-models";
 import { AIImprovementPrompt } from "../../shared/ai-improvement-prompt";
 import { AIGenerationSettingsTooltip } from "../components/ai-generation-tooltip";
 import { ApiErrorDialog } from "@/components/ui/api-error-dialog";
@@ -159,10 +160,9 @@ export const ProjectsForm = memo(function ProjectsFormComponent({
     
     try {
       // Get model and API key from local storage
-      const MODEL_STORAGE_KEY = 'resumelm-default-model';
       const LOCAL_STORAGE_KEY = 'resumelm-api-keys';
 
-      const selectedModel = localStorage.getItem(MODEL_STORAGE_KEY);
+      const selectedModel = getStoredModelSelection();
       const storedKeys = localStorage.getItem(LOCAL_STORAGE_KEY);
       let apiKeys = [];
 
@@ -246,10 +246,9 @@ export const ProjectsForm = memo(function ProjectsFormComponent({
     }));
     
     try {
-      const MODEL_STORAGE_KEY = 'resumelm-default-model';
       const LOCAL_STORAGE_KEY = 'resumelm-api-keys';
 
-      const selectedModel = localStorage.getItem(MODEL_STORAGE_KEY);
+      const selectedModel = getStoredModelSelection();
       const storedKeys = localStorage.getItem(LOCAL_STORAGE_KEY);
       let apiKeys = [];
 

--- a/src/components/resume/editor/forms/work-experience-form.tsx
+++ b/src/components/resume/editor/forms/work-experience-form.tsx
@@ -20,6 +20,7 @@ import {
 import Tiptap from "@/components/ui/lazy-tiptap";
 import { generateWorkExperiencePoints, improveWorkExperience } from "@/utils/actions/resumes/ai";
 import { AIImprovementPrompt } from "../../shared/ai-improvement-prompt";
+import { getStoredModelSelection } from "@/lib/ai-models";
 import { AIGenerationSettingsTooltip } from "../components/ai-generation-tooltip";
 import { AISuggestions } from "../../shared/ai-suggestions";
 
@@ -162,10 +163,9 @@ export const WorkExperienceForm = memo(function WorkExperienceFormComponent({
     
     try {
       // Get model and API key from local storage
-      const MODEL_STORAGE_KEY = 'resumelm-default-model';
       const LOCAL_STORAGE_KEY = 'resumelm-api-keys';
 
-      const selectedModel = localStorage.getItem(MODEL_STORAGE_KEY);
+      const selectedModel = getStoredModelSelection();
       const storedKeys = localStorage.getItem(LOCAL_STORAGE_KEY);
       let apiKeys = [];
 
@@ -251,10 +251,9 @@ export const WorkExperienceForm = memo(function WorkExperienceFormComponent({
     
     try {
       // Get model and API key from local storage
-      const MODEL_STORAGE_KEY = 'resumelm-default-model';
       const LOCAL_STORAGE_KEY = 'resumelm-api-keys';
 
-      const selectedModel = localStorage.getItem(MODEL_STORAGE_KEY);
+      const selectedModel = getStoredModelSelection();
       const storedKeys = localStorage.getItem(LOCAL_STORAGE_KEY);
       let apiKeys = [];
 

--- a/src/components/resume/editor/panels/cover-letter-panel.tsx
+++ b/src/components/resume/editor/panels/cover-letter-panel.tsx
@@ -10,6 +10,7 @@ import { generate } from "@/utils/actions/cover-letter/actions";
 import { useResumeContext } from "../resume-editor-context";
 import { ApiErrorDialog } from "@/components/ui/api-error-dialog";
 import { CreateTailoredResumeDialog } from "@/components/resume/management/dialogs/create-tailored-resume-dialog";
+import { getStoredModelSelection } from "@/lib/ai-models";
 
 
 interface CoverLetterPanelProps {
@@ -44,10 +45,9 @@ export function CoverLetterPanel({
     
     try {
       // Get model and API key from local storage
-      const MODEL_STORAGE_KEY = 'resumelm-default-model';
       const LOCAL_STORAGE_KEY = 'resumelm-api-keys';
 
-      const selectedModel = localStorage.getItem(MODEL_STORAGE_KEY);
+      const selectedModel = getStoredModelSelection();
       const storedKeys = localStorage.getItem(LOCAL_STORAGE_KEY);
       let apiKeys = [];
 
@@ -257,4 +257,4 @@ export function CoverLetterPanel({
       />
     </div>
   );
-} 
+}

--- a/src/components/resume/management/cards/tailored-job-card.tsx
+++ b/src/components/resume/management/cards/tailored-job-card.tsx
@@ -17,6 +17,7 @@ import { Textarea } from "@/components/ui/textarea";
 import { toast } from "@/hooks/use-toast";
 import { Alert, AlertDescription } from "@/components/ui/alert";
 import { cn } from "@/lib/utils";
+import { getStoredModelSelection } from "@/lib/ai-models";
 import { useResumeContext } from "../../editor/resume-editor-context";
 import { AccordionItem, AccordionTrigger, AccordionContent } from "@/components/ui/accordion";
 import { BriefcaseIcon } from "lucide-react";
@@ -131,10 +132,9 @@ export function TailoredJobCard({
       setIsFormatting(true);
 
       // Get model and API key from local storage
-      const MODEL_STORAGE_KEY = 'resumelm-default-model';
       const LOCAL_STORAGE_KEY = 'resumelm-api-keys';
 
-      const selectedModel = localStorage.getItem(MODEL_STORAGE_KEY);
+      const selectedModel = getStoredModelSelection();
       const storedKeys = localStorage.getItem(LOCAL_STORAGE_KEY);
       let apiKeys = [];
 
@@ -563,4 +563,4 @@ export function TailoredJobAccordion({
       </AccordionContent>
     </AccordionItem>
   );
-} 
+}

--- a/src/components/resume/management/dialogs/create-base-resume-dialog.tsx
+++ b/src/components/resume/management/dialogs/create-base-resume-dialog.tsx
@@ -19,6 +19,7 @@ import { Accordion, AccordionItem, AccordionTrigger, AccordionContent } from "@/
 import { Textarea } from "@/components/ui/textarea";
 import { convertTextToResume } from "@/utils/actions/resumes/ai";
 import { ApiErrorDialog } from "@/components/ui/api-error-dialog";
+import { getStoredModelSelection } from "@/lib/ai-models";
 
 interface CreateBaseResumeDialogProps {
   children: React.ReactNode;
@@ -159,9 +160,8 @@ export function CreateBaseResumeDialog({ children, profile }: CreateBaseResumeDi
         };
 
         // Get model and API key from local storage
-        const MODEL_STORAGE_KEY = 'resumelm-default-model';
         const LOCAL_STORAGE_KEY = 'resumelm-api-keys';
-        const selectedModel = localStorage.getItem(MODEL_STORAGE_KEY);
+        const selectedModel = getStoredModelSelection();
         const storedKeys = localStorage.getItem(LOCAL_STORAGE_KEY);
         let apiKeys = [];
         try {

--- a/src/components/resume/management/dialogs/create-tailored-resume-dialog.tsx
+++ b/src/components/resume/management/dialogs/create-tailored-resume-dialog.tsx
@@ -19,6 +19,7 @@ import { ImportMethodRadioGroup } from "../import-method-radio-group";
 import { JobDescriptionInput } from "../job-description-input";
 import { ApiErrorDialog } from "@/components/ui/api-error-dialog";
 import { cn, withBasePath } from "@/lib/utils";
+import { getStoredModelSelection } from "@/lib/ai-models";
 
 interface CreateTailoredResumeDialogProps {
   children: React.ReactNode;
@@ -123,10 +124,9 @@ export function CreateTailoredResumeDialog({ children, baseResumes, profile }: C
 
         if (jobDescription.trim()) {
           // Get model and API key from local storage
-          const MODEL_STORAGE_KEY = 'resumelm-default-model';
           const LOCAL_STORAGE_KEY = 'resumelm-api-keys';
 
-          const selectedModel = localStorage.getItem(MODEL_STORAGE_KEY);
+          const selectedModel = getStoredModelSelection();
           const storedKeys = localStorage.getItem(LOCAL_STORAGE_KEY);
           let apiKeys = [];
 
@@ -203,10 +203,9 @@ export function CreateTailoredResumeDialog({ children, baseResumes, profile }: C
       }
 
       // Get model and API key from local storage
-      const MODEL_STORAGE_KEY = 'resumelm-default-model';
       const LOCAL_STORAGE_KEY = 'resumelm-api-keys';
 
-      const selectedModel = localStorage.getItem(MODEL_STORAGE_KEY);
+      const selectedModel = getStoredModelSelection();
       const storedKeys = localStorage.getItem(LOCAL_STORAGE_KEY);
       let apiKeys = [];
 

--- a/src/lib/ai-models.test.ts
+++ b/src/lib/ai-models.test.ts
@@ -40,6 +40,7 @@ describe("AI model configuration", () => {
       modelId: "openai/gpt-5.6-luna",
     });
     assert.equal(getCanonicalModelId("openai/gpt-5.5"), "openai/gpt-5.6-terra");
+    assert.equal(getCanonicalModelId("  GPT-5.4-NANO  "), "openai/gpt-5.6-luna");
   });
 
   it("exposes the curated visible catalog", () => {

--- a/src/lib/ai-models.ts
+++ b/src/lib/ai-models.ts
@@ -375,7 +375,36 @@ export const MODEL_DESIGNATIONS = {
 export type ModelDesignation = keyof typeof MODEL_DESIGNATIONS
 
 export function getCanonicalModelId(modelId: string): string {
-  return MODEL_ALIASES[modelId] || modelId
+  let canonical = modelId.trim()
+
+  // Resolve aliases repeatedly so future migrations can point at another
+  // legacy alias without leaving a stale ID in localStorage or telemetry.
+  for (let i = 0; i < 5; i += 1) {
+    const next = MODEL_ALIASES[canonical] ?? MODEL_ALIASES[canonical.toLowerCase()]
+    if (!next || next === canonical) break
+    canonical = next
+  }
+
+  return canonical
+}
+
+/**
+ * Read and migrate the browser's saved model selection in one place. This is
+ * intentionally safe to call from server-rendered modules: it is a no-op
+ * until a browser is available.
+ */
+export function getStoredModelSelection(fallback = ""): string {
+  if (typeof window === "undefined") return fallback
+
+  const storageKey = "resumelm-default-model"
+  const stored = window.localStorage.getItem(storageKey) ?? ""
+  const normalized = getCanonicalModelId(stored || fallback)
+
+  if (normalized !== stored) {
+    window.localStorage.setItem(storageKey, normalized)
+  }
+
+  return normalized
 }
 
 // ========================
@@ -422,23 +451,25 @@ export function isModelAvailable(
   isPro: boolean,
   apiKeys: ApiKey[]
 ): boolean {
-  modelId = getCanonicalModelId(modelId)
-  // Pro users have access to all models
-  if (isPro) return true
-
   const model = getModelById(modelId)
   if (!model) return false
+
+  if (model.availability.requiresPro && !isPro) return false
+
+  // Models marked requiresApiKey cannot use ResumeLM's app-funded key, even
+  // for Pro users. This keeps the selector aligned with server-side access.
+  if (model.availability.requiresApiKey) {
+    return apiKeys.some(
+      key => key.service === model.provider && key.key.trim().length > 0,
+    )
+  }
 
   // Free model allowance
   if (model.features.isFree) return true
 
-  // Check if this is an OpenRouter model (contains forward slash)
-  if (modelId.includes('/')) {
-    return apiKeys.some(key => key.service === 'openrouter')
-  }
-
-  // Check if user has the required API key
-  return apiKeys.some(key => key.service === model.provider)
+  // App-funded OpenRouter models are available to Pro users without a BYOK
+  // key. Other providers require a matching user key.
+  return isPro && model.provider === 'openrouter'
 }
 
 /**

--- a/src/lib/ai/access-control.ts
+++ b/src/lib/ai/access-control.ts
@@ -25,6 +25,22 @@ export interface ResolvedAIRequest {
   requiresRateLimit: boolean;
 }
 
+export type AIRequestAccessCode =
+  | "invalid_model"
+  | "unsupported_provider"
+  | "missing_api_key";
+
+export class AIRequestAccessError extends Error {
+  constructor(
+    message: string,
+    public readonly code: AIRequestAccessCode,
+    public readonly modelId?: string,
+  ) {
+    super(message);
+    this.name = "AIRequestAccessError";
+  }
+}
+
 type HiddenModel = Pick<AIModel, "id" | "name" | "provider" | "features" | "availability">;
 
 const HIDDEN_MODELS: Record<string, HiddenModel> = {};
@@ -34,18 +50,24 @@ function getKnownModel(modelId: string): HiddenModel | undefined {
 }
 
 function findUserKey(apiKeys: ResolveAIRequestInput["apiKeys"], providerId: ServiceName) {
-  return apiKeys.find((apiKey) => apiKey.service === providerId)?.key;
+  return apiKeys.find(
+    (apiKey) => apiKey.service === providerId && apiKey.key.trim().length > 0,
+  )?.key.trim();
 }
 
 function getServerKey(providerId: ServiceName) {
   const provider = getProviderById(providerId);
   if (!provider) {
-    throw new Error(`Unsupported provider: ${providerId}`);
+    throw new AIRequestAccessError(
+      `Unsupported provider: ${providerId}`,
+      "unsupported_provider",
+      providerId,
+    );
   }
 
   return {
     provider,
-    apiKey: process.env[provider.envKey],
+    apiKey: process.env[provider.envKey]?.trim(),
   };
 }
 
@@ -53,12 +75,20 @@ export function resolveAIRequest(input: ResolveAIRequestInput): ResolvedAIReques
   const model = getKnownModel(input.requestedModel);
 
   if (!model) {
-    throw new Error(`Unknown model: ${input.requestedModel}`);
+    throw new AIRequestAccessError(
+      `Unknown model: ${input.requestedModel}`,
+      "invalid_model",
+      input.requestedModel,
+    );
   }
 
   const provider = getProviderById(model.provider);
   if (!provider) {
-    throw new Error(`Unsupported provider: ${model.provider}`);
+    throw new AIRequestAccessError(
+      `Unsupported provider: ${model.provider}`,
+      "unsupported_provider",
+      model.id,
+    );
   }
 
   const freeServerModel =
@@ -67,7 +97,7 @@ export function resolveAIRequest(input: ResolveAIRequestInput): ResolvedAIReques
   if (input.isPro || freeServerModel) {
     const { apiKey } = getServerKey(model.provider);
 
-    if (apiKey) {
+    if (apiKey?.length) {
       return {
         providerId: model.provider,
         modelId: model.id,
@@ -80,7 +110,11 @@ export function resolveAIRequest(input: ResolveAIRequestInput): ResolvedAIReques
 
   const userApiKey = findUserKey(input.apiKeys, model.provider);
   if (!userApiKey) {
-    throw new Error(`${provider.name} API key not found in user configuration`);
+    throw new AIRequestAccessError(
+      `${provider.name} API key not found in user configuration`,
+      "missing_api_key",
+      model.id,
+    );
   }
 
   return {

--- a/src/lib/ai/reliability.test.ts
+++ b/src/lib/ai/reliability.test.ts
@@ -1,0 +1,97 @@
+import assert from "node:assert/strict";
+import { afterEach, describe, it } from "node:test";
+
+import {
+  AIProviderError,
+  assertProviderCircuitClosed,
+  classifyAIError,
+  clearInMemoryAIHealthCache,
+  recordProviderFailure,
+  retryAIProviderCall,
+} from "@/lib/ai/reliability";
+
+const context = {
+  providerId: "openrouter" as const,
+  modelId: "openai/gpt-5.6-luna",
+  apiKey: "test-key",
+  usedServerKey: true,
+};
+
+afterEach(() => {
+  clearInMemoryAIHealthCache();
+});
+
+describe("AI provider reliability", () => {
+  it("does not retry quota exhaustion even when the provider returns 429", () => {
+    const classification = classifyAIError({
+      statusCode: 429,
+      message: "You exceeded your current quota; please check billing",
+    });
+
+    assert.equal(classification.kind, "exhausted_credits");
+    assert.equal(classification.retryable, false);
+  });
+
+  it("retries transient rate limits and server failures", () => {
+    assert.equal(
+      classifyAIError({ statusCode: 429, message: "Too many requests" }).retryable,
+      true,
+    );
+    assert.equal(
+      classifyAIError({ statusCode: 503, message: "Provider unavailable" }).retryable,
+      true,
+    );
+    assert.equal(
+      classifyAIError(new Error("fetch failed: ECONNRESET")).retryable,
+      true,
+    );
+  });
+
+  it("does not retry missing keys or invalid models", () => {
+    assert.equal(
+      classifyAIError(new Error("OpenRouter API key not found in user configuration")).retryable,
+      false,
+    );
+    assert.equal(
+      classifyAIError({ statusCode: 400, message: "Model not found" }).kind,
+      "invalid_model",
+    );
+  });
+
+  it("retries a transient operation at most twice", async () => {
+    let attempts = 0;
+    const waits: number[] = [];
+
+    const result = await retryAIProviderCall(
+      async () => {
+        attempts += 1;
+        if (attempts < 3) {
+          throw { statusCode: 503, message: "temporary outage" };
+        }
+        return "ok";
+      },
+      context,
+      { sleep: async milliseconds => { waits.push(milliseconds); } },
+    );
+
+    assert.equal(result, "ok");
+    assert.equal(attempts, 3);
+    assert.equal(waits.length, 2);
+  });
+
+  it("opens a short-lived circuit for an exhausted key", async () => {
+    await recordProviderFailure(context, {
+      kind: "exhausted_credits",
+      retryable: false,
+      statusCode: 402,
+      message: "No credits remaining",
+    });
+
+    await assert.rejects(
+      () => assertProviderCircuitClosed(context),
+      (error: unknown) =>
+        error instanceof AIProviderError &&
+        error.message.includes("This model is unavailable"),
+    );
+  });
+});

--- a/src/lib/ai/reliability.ts
+++ b/src/lib/ai/reliability.ts
@@ -1,0 +1,482 @@
+import { createHash } from "node:crypto";
+import {
+  type LanguageModelV1Middleware,
+  type LanguageModelV1StreamPart,
+} from "ai";
+
+import {
+  getModelById,
+  getProviderById,
+  MODEL_DESIGNATIONS,
+} from "@/lib/ai-models";
+import type { ServiceName } from "@/lib/types";
+import redis from "@/lib/redis";
+
+export const MODEL_UNAVAILABLE_MESSAGE =
+  "This model is unavailable; switching to ResumeLM’s fast default.";
+export const FAST_DEFAULT_MODEL = MODEL_DESIGNATIONS.FAST_CHEAP_FREE;
+
+const CIRCUIT_TTL_SECONDS = 5 * 60;
+const MAX_ATTEMPTS = 3;
+const DEFAULT_RETRY_DELAY_MS = 250;
+
+export type AIErrorKind =
+  | "missing_api_key"
+  | "invalid_model"
+  | "payment_required"
+  | "exhausted_credits"
+  | "authentication"
+  | "permission_denied"
+  | "transient"
+  | "unknown";
+
+export interface AIErrorClassification {
+  kind: AIErrorKind;
+  retryable: boolean;
+  statusCode?: number;
+  message: string;
+  retryAfterMs?: number;
+}
+
+export interface AIProviderContext {
+  providerId: ServiceName;
+  modelId: string;
+  apiKey: string;
+  usedServerKey: boolean;
+}
+
+export class AIProviderError extends Error {
+  constructor(
+    message: string,
+    public readonly classification: AIErrorClassification,
+    public readonly cause?: unknown,
+  ) {
+    super(message);
+    this.name = "AIProviderError";
+  }
+}
+
+function asRecord(value: unknown): Record<string, unknown> | undefined {
+  return value && typeof value === "object"
+    ? (value as Record<string, unknown>)
+    : undefined;
+}
+
+function parseJson(value: unknown): unknown {
+  if (typeof value !== "string") return value;
+  try {
+    return JSON.parse(value);
+  } catch {
+    return value;
+  }
+}
+
+function errorText(error: unknown): string {
+  if (error instanceof AIProviderError) return error.message;
+
+  const record = asRecord(error);
+  const parsedResponse = parseJson(record?.responseBody);
+  const parsedData = parseJson(record?.data);
+  const values = [
+    error instanceof Error ? error.message : undefined,
+    record?.message,
+    record?.code,
+    record?.type,
+    record?.error_type,
+    record?.error,
+    parsedResponse,
+    parsedData,
+  ];
+
+  return values
+    .filter(value => value !== undefined && value !== null)
+    .map(value => (typeof value === "string" ? value : JSON.stringify(value)))
+    .join(" ")
+    .toLowerCase();
+}
+
+function errorStatus(error: unknown): number | undefined {
+  const record = asRecord(error);
+  const statusCode = record?.statusCode ?? record?.status;
+  return typeof statusCode === "number" ? statusCode : undefined;
+}
+
+function retryAfterMs(error: unknown): number | undefined {
+  const record = asRecord(error);
+  const headers = record?.responseHeaders;
+  if (!headers || typeof headers !== "object") return undefined;
+
+  const retryAfter = (headers as Record<string, unknown>)["retry-after"];
+  if (typeof retryAfter !== "string" && typeof retryAfter !== "number") {
+    return undefined;
+  }
+
+  const seconds = Number(retryAfter);
+  return Number.isFinite(seconds) && seconds >= 0 ? seconds * 1000 : undefined;
+}
+
+export function classifyAIError(error: unknown): AIErrorClassification {
+  if (error instanceof AIProviderError) return error.classification;
+
+  const message = errorText(error);
+  const statusCode = errorStatus(error);
+
+  if (
+    /api key not found|missing api key|no api key|api key is required/.test(message)
+  ) {
+    return {
+      kind: "missing_api_key",
+      retryable: false,
+      statusCode,
+      message,
+    };
+  }
+
+  if (
+    /invalid model|unknown model|model.*(?:not found|does not exist)|no such model|model_not_found|invalid_model|not_found/.test(
+      message,
+    )
+  ) {
+    return {
+      kind: "invalid_model",
+      retryable: false,
+      statusCode,
+      message,
+    };
+  }
+
+  if (
+    statusCode === 402 ||
+    /payment required|payment_required|insufficient credit|credit balance|credits exhausted/.test(
+      message,
+    )
+  ) {
+    return {
+      kind: "payment_required",
+      retryable: false,
+      statusCode,
+      message,
+    };
+  }
+
+  if (
+    /insufficient_quota|quota|no credits|out of credits|exhausted.*(?:credit|quota)/.test(
+      message,
+    )
+  ) {
+    return {
+      kind: "exhausted_credits",
+      retryable: false,
+      statusCode,
+      message,
+    };
+  }
+
+  if (
+    statusCode === 401 ||
+    /invalid api key|incorrect api key|authentication|unauthorized/.test(message)
+  ) {
+    return {
+      kind: "authentication",
+      retryable: false,
+      statusCode,
+      message,
+    };
+  }
+
+  if (
+    statusCode === 403 ||
+    /permission denied|forbidden|access denied/.test(message)
+  ) {
+    return {
+      kind: "permission_denied",
+      retryable: false,
+      statusCode,
+      message,
+    };
+  }
+
+  const isNetworkFailure =
+    /econnreset|econnrefused|enotfound|eai_again|etimedout|network|fetch failed|socket|timed out|timeout/.test(
+      message,
+    );
+  const isTransientStatus =
+    statusCode === 408 ||
+    statusCode === 429 ||
+    (statusCode !== undefined && statusCode >= 500 && statusCode <= 599);
+
+  if (isNetworkFailure || isTransientStatus) {
+    return {
+      kind: "transient",
+      retryable: true,
+      statusCode,
+      message,
+      retryAfterMs: retryAfterMs(error),
+    };
+  }
+
+  return {
+    kind: "unknown",
+    retryable: false,
+    statusCode,
+    message,
+  };
+}
+
+function publicProviderError(
+  error: unknown,
+  classification: AIErrorClassification,
+): AIProviderError {
+  if (error instanceof AIProviderError) return error;
+
+  const message =
+    classification.kind === "transient"
+      ? "ResumeLM’s AI service is temporarily unavailable. Please try again."
+      : MODEL_UNAVAILABLE_MESSAGE;
+
+  return new AIProviderError(message, classification, error);
+}
+
+function sleep(milliseconds: number): Promise<void> {
+  return new Promise(resolve => setTimeout(resolve, milliseconds));
+}
+
+export async function retryAIProviderCall<T>(
+  operation: () => PromiseLike<T>,
+  context: AIProviderContext,
+  options: {
+    maxAttempts?: number;
+    sleep?: (milliseconds: number) => Promise<void>;
+  } = {},
+): Promise<T> {
+  const maxAttempts = options.maxAttempts ?? MAX_ATTEMPTS;
+  const wait = options.sleep ?? sleep;
+
+  for (let attempt = 1; attempt <= maxAttempts; attempt += 1) {
+    try {
+      return await operation();
+    } catch (error) {
+      const classification = classifyAIError(error);
+
+      if (!classification.retryable || attempt >= maxAttempts) {
+        await recordProviderFailure(context, classification);
+        throw publicProviderError(error, classification);
+      }
+
+      const backoff =
+        classification.retryAfterMs ??
+        DEFAULT_RETRY_DELAY_MS * 2 ** (attempt - 1) + Math.floor(Math.random() * 100);
+      await wait(backoff);
+    }
+  }
+
+  throw new Error("AI provider retry loop exited unexpectedly");
+}
+
+function circuitKey(context: Pick<AIProviderContext, "providerId" | "apiKey">) {
+  const fingerprint = createHash("sha256")
+    .update(context.apiKey)
+    .digest("hex")
+    .slice(0, 20);
+  return `ai:circuit:${context.providerId}:${fingerprint}`;
+}
+
+interface CircuitState {
+  failures: number;
+  openedUntil: number;
+  lastKind: AIErrorKind;
+  lastModelId: string;
+}
+
+const memoryCircuit = new Map<string, CircuitState>();
+
+function canUseRedis() {
+  return Boolean(
+    process.env.UPSTASH_REDIS_REST_URL &&
+      process.env.UPSTASH_REDIS_REST_TOKEN,
+  ) || Boolean(process.env.USE_LOCAL_REDIS === "true" && process.env.REDIS_URL);
+}
+
+async function readCircuitState(key: string): Promise<CircuitState | null> {
+  const local = memoryCircuit.get(key);
+  if (local) {
+    if (local.openedUntil > Date.now()) return local;
+    memoryCircuit.delete(key);
+  }
+
+  if (!canUseRedis()) return null;
+
+  try {
+    const remote = await redis.hgetall(key);
+    if (!remote?.openedUntil) return null;
+
+    const state: CircuitState = {
+      failures: Number(remote.failures ?? 0),
+      openedUntil: Number(remote.openedUntil),
+      lastKind: (remote.lastKind as AIErrorKind) ?? "unknown",
+      lastModelId: remote.lastModelId ?? "",
+    };
+
+    if (state.openedUntil <= Date.now()) return null;
+    memoryCircuit.set(key, state);
+    return state;
+  } catch {
+    // Provider protection must never turn into an outage because Redis is down.
+    return null;
+  }
+}
+
+function shouldOpenCircuit(kind: AIErrorKind) {
+  return (
+    kind === "payment_required" ||
+    kind === "exhausted_credits" ||
+    kind === "authentication" ||
+    kind === "permission_denied"
+  );
+}
+
+export async function recordProviderFailure(
+  context: AIProviderContext,
+  classification: AIErrorClassification,
+): Promise<void> {
+  if (!shouldOpenCircuit(classification.kind)) return;
+
+  const key = circuitKey(context);
+  const previous = await readCircuitState(key);
+  const state: CircuitState = {
+    failures: (previous?.failures ?? 0) + 1,
+    openedUntil: Date.now() + CIRCUIT_TTL_SECONDS * 1000,
+    lastKind: classification.kind,
+    lastModelId: context.modelId,
+  };
+
+  memoryCircuit.set(key, state);
+
+  if (!canUseRedis()) return;
+
+  try {
+    await redis.hset(key, {
+      failures: String(state.failures),
+      openedUntil: String(state.openedUntil),
+      lastKind: state.lastKind,
+      lastModelId: state.lastModelId,
+    });
+    await redis.expire(key, CIRCUIT_TTL_SECONDS);
+  } catch {
+    // The in-memory state still protects the current server instance.
+  }
+}
+
+export async function assertProviderCircuitClosed(
+  context: AIProviderContext,
+): Promise<void> {
+  const state = await readCircuitState(circuitKey(context));
+  if (!state) return;
+
+  const classification: AIErrorClassification = {
+    kind: state.lastKind,
+    retryable: false,
+    message: `Provider circuit open for ${context.providerId}`,
+  };
+  throw new AIProviderError(MODEL_UNAVAILABLE_MESSAGE, classification);
+}
+
+export function createAIModelReliabilityMiddleware(
+  context: AIProviderContext,
+): LanguageModelV1Middleware {
+  return {
+    middlewareVersion: "v1",
+    wrapGenerate: ({ doGenerate }) =>
+      retryAIProviderCall(doGenerate, context),
+    wrapStream: async ({ doStream }) => {
+      const result = await retryAIProviderCall(doStream, context);
+      const stream = result.stream.pipeThrough(
+        new TransformStream<LanguageModelV1StreamPart, LanguageModelV1StreamPart>({
+          transform(part, controller) {
+            if (part.type === "error") {
+              const classification = classifyAIError(part.error);
+              void recordProviderFailure(context, classification);
+              controller.enqueue({
+                ...part,
+                error: publicProviderError(part.error, classification),
+              });
+              return;
+            }
+
+            controller.enqueue(part);
+          },
+        }),
+      );
+
+      return { ...result, stream };
+    },
+  };
+}
+
+export interface ModelHealth {
+  modelId: string;
+  provider: ServiceName | "unknown";
+  status: "available" | "unavailable" | "unknown";
+  checkedAt: string;
+  retryAt?: string;
+  message?: string;
+  fallbackModelId: string;
+}
+
+export async function getModelHealth(modelId: string): Promise<ModelHealth> {
+  const model = getModelById(modelId);
+  const checkedAt = new Date().toISOString();
+
+  if (!model) {
+    return {
+      modelId,
+      provider: "unknown",
+      status: "unavailable",
+      checkedAt,
+      message: MODEL_UNAVAILABLE_MESSAGE,
+      fallbackModelId: FAST_DEFAULT_MODEL,
+    };
+  }
+
+  const provider = getProviderById(model.provider);
+  const apiKey = provider?.envKey ? process.env[provider.envKey]?.trim() : undefined;
+
+  // A missing app key is not globally unhealthy: a BYOK user may still use
+  // the provider. The normal request resolver will reject it when no key is
+  // available for the current user.
+  if (!provider || !apiKey) {
+    return {
+      modelId: model.id,
+      provider: model.provider,
+      status: "unknown",
+      checkedAt,
+      fallbackModelId: FAST_DEFAULT_MODEL,
+    };
+  }
+
+  const state = await readCircuitState(circuitKey({ providerId: model.provider, apiKey }));
+  if (!state) {
+    return {
+      modelId: model.id,
+      provider: model.provider,
+      status: "available",
+      checkedAt,
+      fallbackModelId: FAST_DEFAULT_MODEL,
+    };
+  }
+
+  return {
+    modelId: model.id,
+    provider: model.provider,
+    status: "unavailable",
+    checkedAt,
+    retryAt: new Date(state.openedUntil).toISOString(),
+    message: MODEL_UNAVAILABLE_MESSAGE,
+    fallbackModelId: FAST_DEFAULT_MODEL,
+  };
+}
+
+/** Test-only reset without touching Redis. */
+export function clearInMemoryAIHealthCache(): void {
+  memoryCircuit.clear();
+}

--- a/src/lib/ai/task-models.ts
+++ b/src/lib/ai/task-models.ts
@@ -75,11 +75,12 @@ export function withTaskModel(input: TaskModelInput): AIConfig {
 export function dedupeAIConfigs(configs: AIConfig[]): AIConfig[] {
   const seen = new Set<string>();
   return configs.filter((config) => {
-    if (seen.has(config.model)) {
+    const canonicalModel = getCanonicalModelId(config.model);
+    if (seen.has(canonicalModel)) {
       return false;
     }
 
-    seen.add(config.model);
+    seen.add(canonicalModel);
     return true;
   });
 }

--- a/src/lib/ai/usage-ledger.ts
+++ b/src/lib/ai/usage-ledger.ts
@@ -3,10 +3,17 @@ import type { LanguageModelUsage, LanguageModelV1, TelemetrySettings } from "ai"
 import { checkRateLimit } from "@/lib/rateLimiter";
 import { AnalyticsEvents } from "@/lib/analytics/events";
 import { captureServerAnalyticsEvent } from "@/lib/analytics/server";
+import {
+  FAST_DEFAULT_MODEL,
+  AIProviderError,
+  MODEL_UNAVAILABLE_MESSAGE,
+  assertProviderCircuitClosed,
+} from "@/lib/ai/reliability";
 import { getDefaultModel } from "@/lib/ai-models";
 import { buildPostHogAITelemetry } from "@/lib/ai/posthog-telemetry";
 import {
   resolveAIRequest,
+  AIRequestAccessError,
   type ResolvedAIRequest,
 } from "@/lib/ai/access-control";
 import { createAIClientFromResolvedRequest, type AIConfig } from "@/utils/ai-tools";
@@ -18,7 +25,8 @@ export class AIUsageError extends Error {
   constructor(
     message: string,
     public readonly code: "blocked" | "rate_limited" | "failed",
-    public readonly status: number = 500
+    public readonly status: number = 500,
+    public readonly fallbackModelId?: string,
   ) {
     super(message);
     this.name = "AIUsageError";
@@ -179,7 +187,41 @@ export async function startAIUsageRequest(input: {
     throw new AIUsageError(
       error instanceof Error ? error.message : "AI request blocked",
       "blocked",
-      403
+      error instanceof AIRequestAccessError && error.code === "invalid_model" ? 503 : 403,
+      error instanceof AIRequestAccessError && error.code === "invalid_model"
+        ? FAST_DEFAULT_MODEL
+        : undefined,
+    );
+  }
+
+  try {
+    await assertProviderCircuitClosed({
+      providerId: resolved.providerId,
+      modelId: resolved.modelId,
+      apiKey: resolved.apiKey,
+      usedServerKey: resolved.usedServerKey,
+    });
+  } catch (error) {
+    const usageEventId = await recordAIUsageStarted({
+      userId: input.userId,
+      route: input.route,
+      provider: resolved.providerId,
+      model: resolved.modelId,
+      isPro: input.isPro,
+      usedServerKey: resolved.usedServerKey,
+    });
+
+    await recordAIUsageFinished({
+      id: usageEventId,
+      status: "blocked",
+      errorCode: error instanceof Error ? error.message : "provider_circuit_open",
+    });
+
+    throw new AIUsageError(
+      error instanceof AIProviderError ? error.message : MODEL_UNAVAILABLE_MESSAGE,
+      "blocked",
+      503,
+      FAST_DEFAULT_MODEL,
     );
   }
 

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -27,10 +27,11 @@ export const config = {
      * - _next/image (image optimization files)
      * - favicon.ico (favicon file)
      * - api/webhooks (webhook endpoints)
+     * - api/ai/model-health (public, read-only health snapshot)
      * - blog (blog section)
      * - public metadata and media files
      * Run on all other routes to protect them
      */
-    '/((?!_next/static|_next/image|favicon.ico|robots.txt|sitemap.xml|api/webhooks|blog(?:/.*)?|.*\\.(?:svg|png|jpg|jpeg|gif|webp|mp4|webm|mov|m4v|ogv)$).*)',
+    '/((?!_next/static|_next/image|favicon.ico|robots.txt|sitemap.xml|api/webhooks|api/ai/model-health|blog(?:/.*)?|.*\\.(?:svg|png|jpg|jpeg|gif|webp|mp4|webm|mov|m4v|ogv)$).*)',
   ],
 }

--- a/src/utils/actions/cover-letter/actions.ts
+++ b/src/utils/actions/cover-letter/actions.ts
@@ -105,6 +105,7 @@ export async function generate(input: string, config?: AIConfig) {
     (async () => {
       const { textStream } = streamText({
         model: aiClient as LanguageModelV1,
+        maxRetries: 0,
         system,
         prompt: input,
         experimental_telemetry: telemetry,

--- a/src/utils/actions/jobs/ai.ts
+++ b/src/utils/actions/jobs/ai.ts
@@ -8,9 +8,8 @@ import {
 } from "@/lib/zod-schemas";
 import { Job, Resume } from "@/lib/types";
 import { AIConfig } from '@/utils/ai-tools';
-import { MODEL_DESIGNATIONS } from '@/lib/ai-models';
 import { getSubscriptionPlan } from '../stripe/actions';
-import { dedupeAIConfigs, withTaskModel, type AITaskModel } from '@/lib/ai/task-models';
+import { withTaskModel } from '@/lib/ai/task-models';
 import {
   finishAIUsageRequest,
   startAIUsageRequest,
@@ -46,25 +45,6 @@ async function runTrackedAIRequest<T extends { usage?: LanguageModelUsage }>(
   }
 }
 
-function getFallbackConfig(config: AIConfig | undefined, model: string): AIConfig {
-  return {
-    apiKeys: config?.apiKeys || [],
-    ...(config?.customPrompts ? { customPrompts: config.customPrompts } : {}),
-    model,
-  };
-}
-
-// Build model candidates list - prioritize the task model, then cheaper fallbacks.
-function getModelCandidates(config: AIConfig | undefined, isPro: boolean, task: AITaskModel) {
-  const primaryModel = withTaskModel({ task, isPro, config });
-  const fallbackModels: AIConfig[] = [
-    getFallbackConfig(config, MODEL_DESIGNATIONS.FAST_CHEAP),
-    getFallbackConfig(config, 'deepseek/deepseek-v4-flash'),
-  ];
-
-  return dedupeAIConfigs([primaryModel, ...fallbackModels]);
-}
-
 export async function tailorResumeToJob(
   resume: Resume,
   jobListing: z.infer<typeof simplifiedJobSchema>,
@@ -72,23 +52,17 @@ export async function tailorResumeToJob(
 ) {
   const { plan, id } = await getSubscriptionPlan(true);
   const isPro = plan === 'pro';
-  const overallStart = Date.now();
-  const modelCandidates = getModelCandidates(config, isPro, "jobTailoring");
-
-  let lastError: unknown;
-
-  for (const candidate of modelCandidates) {
-    let start = Date.now();
-    try {
-      start = Date.now();
-      console.log(
-        `[TAILOR][TRY] ${candidate.model} | STEP: Tailoring resume content | Subscription: ${isPro ? 'PRO' : 'FREE'}`
-      );
+  const selectedConfig = withTaskModel({ task: "jobTailoring", isPro, config });
+  const start = Date.now();
+  console.log(
+    `[TAILOR][TRY] ${selectedConfig.model} | STEP: Tailoring resume content | Subscription: ${isPro ? 'PRO' : 'FREE'}`
+  );
+  try {
       const { object } = await runTrackedAIRequest({
         route: 'actions.jobs.tailorResumeToJob',
         userId: id,
         isPro,
-        config: candidate,
+        config: selectedConfig,
         useThinking: isPro,
       }, (aiClient, telemetry) => generateObject({
         model: aiClient as LanguageModelV1,
@@ -96,7 +70,7 @@ export async function tailorResumeToJob(
         schema: z.object({
           content: simplifiedResumeSchema,
         }),
-        maxRetries: 2, // retry on failure
+        maxRetries: 0,
         system: `
 
 You are ResumeLM, an advanced AI resume transformer. Rewrite the resume so it is ATS-friendly and tightly aligned to the job description—without adding new facts or inventing experience.
@@ -122,48 +96,34 @@ Your task: produce a polished, tailored resume that meets the schema exactly and
       }));
 
       console.log(
-        `[TAILOR][SUCCESS ✅] ${candidate.model} | Duration: ${Date.now() - start}ms | STEP: Tailoring resume content`
+        `[TAILOR][SUCCESS ✅] ${selectedConfig.model} | Duration: ${Date.now() - start}ms | STEP: Tailoring resume content`
       );
       return object.content satisfies z.infer<typeof simplifiedResumeSchema>;
-    } catch (error) {
-      lastError = error;
-      console.error(
-        `[TAILOR][FAILED ❌] ${candidate.model} | STEP: Tailoring resume content | Duration: ${Date.now() - start}ms | Reason: ${(error as Error)?.message ?? 'Unknown error'}`,
-        error
-      );
-    }
+  } catch (error) {
+    console.error(
+      `[TAILOR][FAILED ❌] ${selectedConfig.model} | STEP: Tailoring resume content | Duration: ${Date.now() - start}ms | Reason: ${(error as Error)?.message ?? 'Unknown error'}`,
+      error
+    );
+    throw error;
   }
-
-  console.error(
-    `[TAILOR][ABORT 🚨] All models failed | Tried: ${modelCandidates.map(m => m.model).join(', ')} | Total Duration: ${
-      Date.now() - overallStart
-    }ms`
-  );
-  throw lastError ?? new Error('Failed to tailor resume');
 }
 
 export async function formatJobListing(jobListing: string, config?: AIConfig) {
   const { plan, id } = await getSubscriptionPlan(true);
   const isPro = plan === 'pro';
-  const overallStart = Date.now();
-  const modelCandidates = getModelCandidates(config, isPro, "structuredExtraction");
-
-  let lastError: unknown;
-
-  for (const candidate of modelCandidates) {
-    let start = Date.now();
-    try {
-      start = Date.now();
-      console.log(
-        `[FORMAT][TRY] ${candidate.model} | STEP: Analyzing job description → Formatting requirements | Subscription: ${
-          isPro ? 'PRO' : 'FREE'
-        }`
-      );
+  const selectedConfig = withTaskModel({ task: "structuredExtraction", isPro, config });
+  const start = Date.now();
+  console.log(
+    `[FORMAT][TRY] ${selectedConfig.model} | STEP: Analyzing job description → Formatting requirements | Subscription: ${
+      isPro ? 'PRO' : 'FREE'
+    }`
+  );
+  try {
       const { object } = await runTrackedAIRequest({
         route: 'actions.jobs.formatJobListing',
         userId: id,
         isPro,
-        config: candidate,
+        config: selectedConfig,
         useThinking: isPro,
       }, (aiClient, telemetry) => generateObject({
         model: aiClient as LanguageModelV1,
@@ -213,25 +173,18 @@ export async function formatJobListing(jobListing: string, config?: AIConfig) {
                 - Avoid exposing your internal reasoning.
                 - DO NOT RETURN "<UNKNOWN>", if you are unsure of a piece of data, return an empty string.
                 - FORMAT THE FOLLOWING JOB LISTING AS A JSON OBJECT: ${jobListing}`,
+        maxRetries: 0,
       }));
 
       console.log(
-        `[FORMAT][SUCCESS ✅] ${candidate.model} | Duration: ${Date.now() - start}ms | STEP: Analyzing job description → Formatting requirements`
+        `[FORMAT][SUCCESS ✅] ${selectedConfig.model} | Duration: ${Date.now() - start}ms | STEP: Analyzing job description → Formatting requirements`
       );
       return object.content satisfies Partial<Job>;
-    } catch (error) {
-      lastError = error;
-      console.error(
-        `[FORMAT][FAILED ❌] ${candidate.model} | STEP: Analyzing job description → Formatting requirements | Duration: ${Date.now() - start}ms | Reason: ${(error as Error)?.message ?? 'Unknown error'}`,
-        error
-      );
-    }
+  } catch (error) {
+    console.error(
+      `[FORMAT][FAILED ❌] ${selectedConfig.model} | STEP: Analyzing job description → Formatting requirements | Duration: ${Date.now() - start}ms | Reason: ${(error as Error)?.message ?? 'Unknown error'}`,
+      error
+    );
+    throw error;
   }
-
-  console.error(
-    `[FORMAT][ABORT 🚨] All models failed | Tried: ${modelCandidates.map(m => m.model).join(', ')} | Total Duration: ${
-      Date.now() - overallStart
-    }ms`
-  );
-  throw lastError ?? new Error('Failed to format job listing');
 }

--- a/src/utils/actions/profiles/ai.ts
+++ b/src/utils/actions/profiles/ai.ts
@@ -57,6 +57,7 @@ export async function formatProfileWithAI(
         config: withTaskModel({ task: "structuredExtraction", isPro, config }),
       }, (aiClient, telemetry) => generateObject({
         model: aiClient as LanguageModelV1,
+        maxRetries: 0,
         experimental_telemetry: telemetry,
         schema: z.object({
           content: z.object({

--- a/src/utils/actions/resumes/actions.ts
+++ b/src/utils/actions/resumes/actions.ts
@@ -623,6 +623,7 @@ export async function generateResumeScore(
       config: withTaskModel({ task: "resumeScoring", isPro, config }),
     }, (aiClient, telemetry) => generateObject({
       model: aiClient,
+      maxRetries: 0,
       experimental_telemetry: telemetry,
       schema: resumeScoreSchema,
       prompt

--- a/src/utils/actions/resumes/ai.ts
+++ b/src/utils/actions/resumes/ai.ts
@@ -76,6 +76,7 @@ export async function convertTextToResume(prompt: string, existingResume: Resume
       },
       (aiClient, telemetry) => generateObject({
         model: aiClient,
+        maxRetries: 0,
         experimental_telemetry: telemetry,
         schema: z.object({
           content: textImportSchema
@@ -161,6 +162,7 @@ export async function convertTextToResume(prompt: string, existingResume: Resume
         config: withTaskModel({ task: "contentGeneration", isPro, config }),
       }, (aiClient, telemetry) => generateObject({
         model: aiClient,
+        maxRetries: 0,
         experimental_telemetry: telemetry,
         schema: z.object({
           content: workExperienceBulletPointsSchema
@@ -191,6 +193,7 @@ export async function convertTextToResume(prompt: string, existingResume: Resume
           config: withTaskModel({ task: "simpleRewrite", isPro, config }),
           }, (aiClient, telemetry) => generateObject({
           model: aiClient,
+          maxRetries: 0,
           experimental_telemetry: telemetry,
           
           schema: z.object({
@@ -220,6 +223,7 @@ export async function convertTextToResume(prompt: string, existingResume: Resume
           config: withTaskModel({ task: "simpleRewrite", isPro, config }),
           }, (aiClient, telemetry) => generateObject({
           model: aiClient,
+          maxRetries: 0,
           experimental_telemetry: telemetry,
           schema: z.object({
               content: z.string().describe("The improved project bullet point")
@@ -253,6 +257,7 @@ export async function convertTextToResume(prompt: string, existingResume: Resume
           config: withTaskModel({ task: "contentGeneration", isPro, config }),
           }, (aiClient, telemetry) => generateObject({
           model: aiClient,
+          maxRetries: 0,
           experimental_telemetry: telemetry,
           schema: z.object({
               content: projectAnalysisSchema
@@ -282,6 +287,7 @@ export async function convertTextToResume(prompt: string, existingResume: Resume
           config: withTaskModel({ task: "structuredExtraction", isPro, config }),
           }, (aiClient, telemetry) => generateObject({
           model: aiClient,
+          maxRetries: 0,
           experimental_telemetry: telemetry,
           schema: z.object({
               content: textImportSchema
@@ -308,6 +314,7 @@ export async function convertTextToResume(prompt: string, existingResume: Resume
           config: withTaskModel({ task: "simpleRewrite", isPro, config }),
           }, (aiClient, telemetry) => generateObject({
           model: aiClient,
+          maxRetries: 0,
           experimental_telemetry: telemetry,
           schema: z.object({
               content: workExperienceItemsSchema
@@ -337,6 +344,7 @@ export async function convertTextToResume(prompt: string, existingResume: Resume
           config: withTaskModel({ task: "structuredExtraction", isPro, config }),
           }, (aiClient, telemetry) => generateObject({
           model: aiClient,
+          maxRetries: 0,
           experimental_telemetry: telemetry,
           schema: z.object({
               content: textImportSchema

--- a/src/utils/ai-tools.ts
+++ b/src/utils/ai-tools.ts
@@ -1,12 +1,13 @@
 import { createOpenAI } from '@ai-sdk/openai';
 import { createAnthropic } from '@ai-sdk/anthropic';
 import { createOpenRouter } from '@openrouter/ai-sdk-provider';
-import { LanguageModelV1 } from 'ai';
+import { LanguageModelV1, wrapLanguageModel } from 'ai';
 import { type AIConfig } from '@/lib/ai-models';
 import {
   resolveAIRequest,
   type ResolvedAIRequest,
 } from '@/lib/ai/access-control';
+import { createAIModelReliabilityMiddleware } from '@/lib/ai/reliability';
 
 // Re-export types for backward compatibility
 export type { ApiKey, AIConfig } from '@/lib/ai-models';
@@ -17,18 +18,22 @@ export function createAIClientFromResolvedRequest(
 ) {
   void useThinking; // Keep for future use
 
+  let baseModel: LanguageModelV1;
+
   switch (resolved.providerId) {
     case 'anthropic':
-      return createAnthropic({ apiKey: resolved.apiKey })(resolved.modelId) as LanguageModelV1;
+      baseModel = createAnthropic({ apiKey: resolved.apiKey })(resolved.modelId) as LanguageModelV1;
+      break;
     
     case 'openai':
-      return createOpenAI({ 
+      baseModel = createOpenAI({
         apiKey: resolved.apiKey,
         compatibility: 'strict'
       })(resolved.modelId) as LanguageModelV1;
+      break;
     
     case 'openrouter':
-      return createOpenRouter({
+      baseModel = createOpenRouter({
         apiKey: resolved.apiKey,
         baseURL: 'https://openrouter.ai/api/v1',
         headers: {
@@ -36,10 +41,21 @@ export function createAIClientFromResolvedRequest(
           'X-Title': 'ResumeLM'
         }
       })(resolved.modelId) as LanguageModelV1;
+      break;
     
     default:
       throw new Error(`Unsupported provider: ${resolved.providerId}`);
   }
+
+  return wrapLanguageModel({
+    model: baseModel,
+    middleware: createAIModelReliabilityMiddleware({
+      providerId: resolved.providerId,
+      modelId: resolved.modelId,
+      apiKey: resolved.apiKey,
+      usedServerKey: resolved.usedServerKey,
+    }),
+  });
 }
 
 export function resolveAIClient(config?: AIConfig, isPro?: boolean, useThinking?: boolean) {


### PR DESCRIPTION
## Summary
- Canonicalize and migrate legacy GPT model IDs, including stored `gpt-5.4-nano` selections, to ResumeLM's OpenRouter defaults.
- Add one shared provider reliability policy with transient-only retries, terminal error classification, per-key circuit breaking, and a public short-lived model-health snapshot.
- Remove blind job-model fallback loops and disable the AI SDK's implicit retries across all generation/streaming paths.
- Route the Settings API-key test through OpenRouter instead of sending an OpenRouter model ID to the direct OpenAI SDK.
- Update localStorage readers and the public-contract check for the route-group layout.

## Validation
- `pnpm typecheck`
- `pnpm test` — 80 passing
- `pnpm check:trust`
- `STRIPE_SECRET_KEY=sk_test_local pnpm build`
- Built local server smoke-tested on `localhost:3001`: marketing/auth pages return 200; `/api/ai/model-health?model=gpt-5.4-nano` returns canonical `openai/gpt-5.6-luna`; unknown models return the fallback message.

PostHog research showed the historical failure pattern this addresses: direct `gpt-5.4-nano` quota failures, missing direct OpenAI keys, and OpenRouter payment-required failures.