### PR TITLE
Enable Google OAuth PKCE flow IDs

### DIFF
--- a/src/app/(auth)/auth/login/actions.ts
+++ b/src/app/(auth)/auth/login/actions.ts
@@ -234,7 +234,7 @@ export async function resetPasswordForEmail(formData: FormData): Promise<AuthRes
 
 // Google Sign In
 export async function signInWithGoogle(intent?: AuthIntent): Promise<OAuthAuthResult> {
-  const supabase = await createClient();
+  const supabase = await createClient({ appendPkceFlowIdToRedirects: true });
 
   try {
     const { data, error } = await supabase.auth.signInWithOAuth({

--- a/src/utils/supabase/server.ts
+++ b/src/utils/supabase/server.ts
@@ -1,14 +1,25 @@
 import { createServerClient } from '@supabase/ssr'
 import { cookies } from 'next/headers'
 
-export async function createClient() {
+type ServerClientOptions = {
+  appendPkceFlowIdToRedirects?: boolean
+}
+
+export async function createClient(options: ServerClientOptions = {}) {
   const cookieStore = await cookies()
 
   return createServerClient(
     process.env.NEXT_PUBLIC_SUPABASE_URL!,
     process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
     {
-      
+      auth: options.appendPkceFlowIdToRedirects
+        ? {
+            flowType: 'pkce',
+            experimental: {
+              appendPkceFlowIdToRedirects: true,
+            },
+          }
+        : undefined,
       cookies: {
         getAll() {
           return cookieStore.getAll()


### PR DESCRIPTION
## Summary
- opt Google sign-in into Supabase's PKCE flow-ID redirect handling
- preserve the flow ID through the callback so concurrent OAuth attempts exchange the correct code
- leave other auth clients unchanged

## Validation
- pnpm test
- pnpm typecheck
- pnpm lint
- pnpm check:trust
- pnpm build
- local browser OAuth start verified `sb_flow_id` is appended to the callback URL