### PR TITLE
Optimize dashboard reads and measure outbound attribution

### DIFF
--- a/src/app/(auth)/auth/login/page.tsx
+++ b/src/app/(auth)/auth/login/page.tsx
@@ -107,6 +107,7 @@ export default async function LoginPage({
                   <a
                     href={trackedGitHubUrl}
                     data-analytics-id="outbound-github-repo"
+                    data-analytics-placement="auth_login"
                     target="_blank"
                     rel="noopener noreferrer"
                     className="inline-flex items-center gap-2.5 px-4 py-2 rounded-full 

--- a/src/app/(dashboard)/layout.tsx
+++ b/src/app/(dashboard)/layout.tsx
@@ -13,7 +13,10 @@ import {
   parseImpersonationStateCookieValue,
 } from "@/lib/impersonation";
 import { getSubscriptionAccessState } from "@/lib/subscription-access";
-import { createClient } from "@/utils/supabase/server";
+import {
+  getAuthenticatedUser,
+  getDashboardSubscription,
+} from "@/utils/actions";
 
 const isVercel = process.env.VERCEL === "1";
 
@@ -22,10 +25,7 @@ export const dynamic = "force-dynamic";
 export default async function DashboardLayout({
   children,
 }: Readonly<{ children: React.ReactNode }>) {
-  const supabase = await createClient();
-  const {
-    data: { user },
-  } = await supabase.auth.getUser();
+  const user = await getAuthenticatedUser();
 
   if (!user) {
     redirect("/");
@@ -43,13 +43,7 @@ export default async function DashboardLayout({
   let upgradeButtonVariant: "trial" | "upgrade" = "upgrade";
 
   try {
-    const { data: subscription } = await supabase
-      .from("subscriptions")
-      .select(
-        "subscription_plan, subscription_status, current_period_end, trial_end, stripe_subscription_id",
-      )
-      .eq("user_id", user.id)
-      .maybeSingle();
+    const { data: subscription } = await getDashboardSubscription(user.id);
 
     const subscriptionState = getSubscriptionAccessState(subscription);
     isProPlan = subscriptionState.hasProAccess;

--- a/src/components/analytics/outbound-link-tracker.tsx
+++ b/src/components/analytics/outbound-link-tracker.tsx
@@ -1,0 +1,57 @@
+'use client';
+
+import { useEffect } from 'react';
+import { usePostHog } from 'posthog-js/react';
+import {
+  getAttributionProperties,
+  getBrowserStorage,
+  getUtmParameters,
+  persistFirstTouchAttribution,
+} from '@/lib/analytics/attribution';
+import { AnalyticsEvents, sanitizeAnalyticsProperties } from '@/lib/analytics/events';
+import {
+  buildOutboundLinkProperties,
+  isExternalHttpLink,
+} from '@/lib/analytics/outbound';
+
+export function OutboundLinkTracker() {
+  const posthog = usePostHog();
+
+  useEffect(() => {
+    if (!posthog) return;
+
+    function handleClick(event: MouseEvent) {
+      const target = event.target;
+      if (!(target instanceof Element)) return;
+
+      const anchor = target.closest<HTMLAnchorElement>('a[data-analytics-id]');
+      if (!anchor || !isExternalHttpLink(anchor.href, window.location.origin)) return;
+
+      const currentAttribution = getUtmParameters(window.location.search);
+      const firstTouchAttribution = persistFirstTouchAttribution(
+        currentAttribution,
+        getBrowserStorage(),
+      );
+
+      posthog.capture(
+        AnalyticsEvents.OutboundLinkClicked,
+        sanitizeAnalyticsProperties({
+          ...buildOutboundLinkProperties({
+            href: anchor.href,
+            linkId: anchor.dataset.analyticsId,
+            placement: anchor.dataset.analyticsPlacement,
+            text: anchor.textContent,
+            pathname: window.location.pathname,
+            opensInNewTab: anchor.target === '_blank',
+          }),
+          ...getAttributionProperties(currentAttribution, firstTouchAttribution),
+        }),
+      );
+    }
+
+    document.addEventListener('click', handleClick, true);
+    return () => document.removeEventListener('click', handleClick, true);
+  }, [posthog]);
+
+  return null;
+}

--- a/src/components/analytics/posthog-provider.tsx
+++ b/src/components/analytics/posthog-provider.tsx
@@ -4,6 +4,7 @@ import { useEffect } from 'react';
 import posthog from 'posthog-js';
 import { PostHogProvider as PostHogReactProvider } from 'posthog-js/react';
 import { sanitizeAnalyticsProperties } from '@/lib/analytics/events';
+import { OutboundLinkTracker } from './outbound-link-tracker';
 
 const posthogKey = process.env.NEXT_PUBLIC_POSTHOG_KEY;
 const posthogHost = process.env.NEXT_PUBLIC_POSTHOG_HOST ?? 'https://us.i.posthog.com';
@@ -68,6 +69,7 @@ export function PostHogProvider({
 
   return (
     <PostHogReactProvider client={posthog}>
+      <OutboundLinkTracker />
       {children}
     </PostHogReactProvider>
   );

--- a/src/components/landing/FeatureHighlights.tsx
+++ b/src/components/landing/FeatureHighlights.tsx
@@ -259,6 +259,7 @@ const FeatureHighlights = () => {
             <Link 
               href={trackedGitHubUrl}
               data-analytics-id="outbound-github-repo"
+              data-analytics-placement="landing_feature_highlights"
               target="_blank"
               rel="noopener noreferrer"
               className="px-8 py-4 rounded-lg bg-white/80 border border-purple-200/40 text-lg font-medium transition-all duration-300 hover:-translate-y-1 hover:shadow-lg"

--- a/src/components/landing/Hero.tsx
+++ b/src/components/landing/Hero.tsx
@@ -41,6 +41,7 @@ export function Hero() {
           <Link 
             href={trackedGitHubUrl}
             data-analytics-id="outbound-github-repo"
+            data-analytics-placement="landing_hero"
             target="_blank"
             rel="noopener noreferrer"
             className="px-6 py-3 rounded-lg bg-white/40 border border-gray-200 font-medium transition-all duration-300 hover:-translate-y-1"

--- a/src/components/landing/action-buttons.tsx
+++ b/src/components/landing/action-buttons.tsx
@@ -21,15 +21,22 @@ export function ActionButtons() {
         {/* <WaitlistDialog /> */}
       </div>
       
-      <Button 
-        size="sm" 
-        variant="ghost" 
+      <Button
+        asChild
+        size="sm"
+        variant="ghost"
         className="text-xs text-muted-foreground hover:text-foreground border-none px-4 py-2 transition-colors duration-300 self-start"
-        onClick={() => window.open(trackedRepoUrl, '_blank', 'noopener,noreferrer')}
-        data-analytics-id="outbound-github-repo"
       >
-        <Github className="mr-2 w-3.5 h-3.5" />
-        Source Code on GitHub
+        <a
+          href={trackedRepoUrl}
+          target="_blank"
+          rel="noopener noreferrer"
+          data-analytics-id="outbound-github-repo"
+          data-analytics-placement="landing_action_buttons"
+        >
+          <Github className="mr-2 w-3.5 h-3.5" />
+          Source Code on GitHub
+        </a>
       </Button>
     </div>
   );

--- a/src/components/landing/creator-story.tsx
+++ b/src/components/landing/creator-story.tsx
@@ -94,6 +94,7 @@ export function CreatorStory() {
                   <motion.a 
                     href={trackedCreatorXUrl}
                     data-analytics-id="outbound-creator-x"
+                    data-analytics-placement="landing_creator_story"
                     target="_blank" 
                     rel="noopener noreferrer"
                     className="flex items-center gap-2 px-4 py-2 rounded-lg bg-indigo-50 border border-indigo-200 text-indigo-700 transition-all duration-300 hover:-translate-y-1"
@@ -108,6 +109,7 @@ export function CreatorStory() {
                   <motion.a 
                     href={trackedCreatorGitHubUrl}
                     data-analytics-id="outbound-creator-github"
+                    data-analytics-placement="landing_creator_story"
                     target="_blank" 
                     rel="noopener noreferrer"
                     className="flex items-center gap-2 px-4 py-2 rounded-lg bg-teal-50 border border-teal-200 text-teal-700 transition-all duration-300 hover:-translate-y-1"

--- a/src/components/landing/github-badge.tsx
+++ b/src/components/landing/github-badge.tsx
@@ -12,16 +12,17 @@ export function GitHubBadge() {
   });
 
   return (
-    <div 
-      onClick={() => window.open(trackedRepoUrl, '_blank', 'noopener,noreferrer')}
-      role="link"
-      tabIndex={0}
+    <a
+      href={trackedRepoUrl}
+      target="_blank"
+      rel="noopener noreferrer"
       aria-label="Open ResumeLM source code on GitHub"
       data-analytics-id="outbound-github-repo"
+      data-analytics-placement="landing_github_badge"
       className="inline-flex items-center gap-2.5 px-5 py-2.5 rounded-full bg-purple-50/80 border border-purple-200 text-purple-600 w-fit cursor-pointer hover:bg-purple-100/80 transition-colors">
       <Github className="w-4 h-4" />
       <span className="text-sm font-medium">Open Source on GitHub</span>
       <ChevronRight className="w-4 h-4" />
-    </div>
+    </a>
   );
 }

--- a/src/components/layout/footer.tsx
+++ b/src/components/layout/footer.tsx
@@ -47,6 +47,7 @@ export function Footer({ variant = 'fixed' }: FooterProps) {
             <Link
               href={trackedCreatorXUrl}
               data-analytics-id="outbound-creator-x"
+              data-analytics-placement="footer"
               target="_blank"
               rel="noopener noreferrer"
               className="text-muted-foreground hover:text-foreground transition-colors p-1"
@@ -56,6 +57,7 @@ export function Footer({ variant = 'fixed' }: FooterProps) {
             <Link
               href={trackedCreatorLinkedInUrl}
               data-analytics-id="outbound-creator-linkedin"
+              data-analytics-placement="footer"
               target="_blank"
               rel="noopener noreferrer"
               className="text-muted-foreground hover:text-foreground transition-colors p-1"
@@ -65,6 +67,7 @@ export function Footer({ variant = 'fixed' }: FooterProps) {
             <Link
               href={trackedCreatorGitHubUrl}
               data-analytics-id="outbound-creator-github"
+              data-analytics-placement="footer"
               target="_blank"
               rel="noopener noreferrer"
               className="text-muted-foreground hover:text-foreground transition-colors p-1"

--- a/src/lib/analytics/outbound.test.ts
+++ b/src/lib/analytics/outbound.test.ts
@@ -1,0 +1,43 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+
+import {
+  buildOutboundLinkProperties,
+  isExternalHttpLink,
+} from "./outbound";
+
+describe("outbound analytics", () => {
+  it("recognizes external HTTP links without treating internal routes as outbound", () => {
+    assert.equal(
+      isExternalHttpLink("https://github.com/olyaiy/resume-lm?utm_source=resumelm", "https://resumelm.ca"),
+      true,
+    );
+    assert.equal(isExternalHttpLink("/profile", "https://resumelm.ca"), false);
+    assert.equal(isExternalHttpLink("mailto:support@example.com", "https://resumelm.ca"), false);
+  });
+
+  it("captures safe destination, placement, text, and destination UTM fields", () => {
+    assert.deepEqual(
+      buildOutboundLinkProperties({
+        href: "https://github.com/olyaiy/resume-lm?utm_source=resumelm&utm_medium=referral&utm_campaign=landing",
+        linkId: "outbound-github-repo",
+        text: "  View source code   on GitHub  ",
+        pathname: "/",
+        opensInNewTab: true,
+      }),
+      {
+        link_id: "outbound-github-repo",
+        link_placement: "outbound-github-repo",
+        link_text: "View source code on GitHub",
+        destination_host: "github.com",
+        destination_path: "/olyaiy/resume-lm",
+        destination_protocol: "https",
+        current_pathname: "/",
+        opens_in_new_tab: true,
+        destination_utm_source: "resumelm",
+        destination_utm_medium: "referral",
+        destination_utm_campaign: "landing",
+      },
+    );
+  });
+});

--- a/src/lib/analytics/outbound.ts
+++ b/src/lib/analytics/outbound.ts
@@ -1,0 +1,51 @@
+import { sanitizeAnalyticsProperties } from "./events";
+
+const MAX_LINK_TEXT_LENGTH = 120;
+
+export interface OutboundLinkInput {
+  href: string;
+  linkId?: string | null;
+  placement?: string | null;
+  text?: string | null;
+  pathname?: string | null;
+  opensInNewTab?: boolean;
+}
+
+function normalizeText(value: string | null | undefined): string | undefined {
+  const normalized = value?.replace(/\s+/g, " ").trim();
+  return normalized ? normalized.slice(0, MAX_LINK_TEXT_LENGTH) : undefined;
+}
+
+export function isExternalHttpLink(href: string, currentOrigin: string): boolean {
+  try {
+    const url = new URL(href, currentOrigin);
+    return (
+      (url.protocol === "http:" || url.protocol === "https:") &&
+      url.origin !== currentOrigin
+    );
+  } catch {
+    return false;
+  }
+}
+
+export function buildOutboundLinkProperties(input: OutboundLinkInput) {
+  const url = new URL(input.href, "https://resumelm.local");
+  const destinationUtm = {
+    destination_utm_source: url.searchParams.get("utm_source") ?? undefined,
+    destination_utm_medium: url.searchParams.get("utm_medium") ?? undefined,
+    destination_utm_campaign: url.searchParams.get("utm_campaign") ?? undefined,
+    destination_utm_content: url.searchParams.get("utm_content") ?? undefined,
+  };
+
+  return sanitizeAnalyticsProperties({
+    link_id: input.linkId,
+    link_placement: input.placement ?? input.linkId,
+    link_text: normalizeText(input.text),
+    destination_host: url.host,
+    destination_path: url.pathname,
+    destination_protocol: url.protocol.replace(":", ""),
+    current_pathname: input.pathname,
+    opens_in_new_tab: input.opensInNewTab,
+    ...destinationUtm,
+  });
+}

--- a/src/utils/actions.ts
+++ b/src/utils/actions.ts
@@ -3,6 +3,7 @@
 import { createClient } from "@/utils/supabase/server";
 import { Profile, ResumeSummary } from "@/lib/types";
 import { getSubscriptionAccessState } from "@/lib/subscription-access";
+import { cache } from "react";
 
 interface DashboardData {
   profile: Profile | null;
@@ -27,13 +28,37 @@ const FALLBACK_SUBSCRIPTION: DashboardData["subscription"] = {
   hasProAccess: false,
 };
 
-export async function getDashboardData(): Promise<DashboardData> {
+// React request memoization lets the dashboard layout and page share the
+// authenticated user and subscription reads instead of repeating them in a
+// single server render.
+export const getAuthenticatedUser = cache(async () => {
   const supabase = await createClient();
-  const { data: { user }, error } = await supabase.auth.getUser();
-  
-  if (error || !user) {
+  const {
+    data: { user },
+    error,
+  } = await supabase.auth.getUser();
+
+  if (error || !user) return null;
+  return user;
+});
+
+export const getDashboardSubscription = cache(async (userId: string) => {
+  const supabase = await createClient();
+  return supabase
+    .from('subscriptions')
+    .select('subscription_plan, subscription_status, stripe_subscription_id, current_period_end, trial_end')
+    .eq('user_id', userId)
+    .maybeSingle();
+});
+
+export async function getDashboardData(): Promise<DashboardData> {
+  const user = await getAuthenticatedUser();
+
+  if (!user) {
     throw new Error('User not authenticated');
   }
+
+  const supabase = await createClient();
 
   try {
     // These reads are independent. Running them together removes a full
@@ -48,11 +73,7 @@ export async function getDashboardData(): Promise<DashboardData> {
         .from('resumes')
         .select('id, user_id, name, target_role, is_base_resume, job_id, created_at, updated_at')
         .eq('user_id', user.id),
-      supabase
-        .from('subscriptions')
-        .select('subscription_plan, subscription_status, stripe_subscription_id, current_period_end, trial_end')
-        .eq('user_id', user.id)
-        .maybeSingle(),
+      getDashboardSubscription(user.id),
     ]);
 
     const { data, error: profileError } = profileResult;
@@ -137,5 +158,4 @@ export async function getDashboardData(): Promise<DashboardData> {
     throw error;
   }
 }
-
 


### PR DESCRIPTION
## What changed

- Memoize the authenticated user and dashboard subscription reads so the dashboard layout and /home page share the same server-render request work.
- Add a global PostHog outbound-link tracker for external HTTP(S) anchors.
- Capture safe destination, UTM, current pathname, placement, link ID, and new-tab metadata.
- Convert the remaining GitHub controls that used window.open into real anchors so they participate in tracking.
- Add focused outbound analytics tests and placement metadata for GitHub/social links.

## Why

Production Supabase logs showed /home doing duplicate auth and subscription reads: middleware, dashboard layout, and getDashboardData each touched auth, while layout and page both queried subscription state. The memoized helpers remove the layout/page duplication without changing access behavior.

The production audit also showed GitHub UTM pageviews but no dedicated click event, so traffic from the README could be seen only after arrival. This makes GitHub and social contribution measurable by source, campaign, destination, and placement.

## Validation

- pnpm test — 87 passing
- pnpm typecheck
- pnpm lint
- pnpm check:trust
- pnpm build with placeholder non-secret environment values
- Local production server smoke-tested on http://localhost:3001/; landing page rendered, outbound metadata was present, and unauthenticated /home redirected to /.