### PR TITLE
Fix dashboard greeting hydration mismatch

### DIFF
--- a/src/app/(dashboard)/home/page.tsx
+++ b/src/app/(dashboard)/home/page.tsx
@@ -16,8 +16,8 @@ import {User } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Card } from "@/components/ui/card";
 import { ProfileRow } from "@/components/dashboard/profile-row";
+import { Greeting } from "@/components/dashboard/greeting";
 import { WelcomeDialog } from "@/components/dashboard/welcome-dialog";
-import { getGreeting } from "@/lib/utils";
 import { ApiKeyAlert } from "@/components/dashboard/api-key-alert";
 import { type SortOption, type SortDirection } from "@/components/resume/management/resume-sort-controls";
 import type { ResumeSummary } from "@/lib/types";
@@ -150,9 +150,7 @@ export default async function Home({
             {/* Greeting & Edit Button */}
             <div className="flex items-center justify-between">
               <div>
-                <h1 className="text-2xl font-semibold bg-gradient-to-r from-teal-600 to-cyan-600 bg-clip-text text-transparent">
-                  {getGreeting()}, {profile.first_name}
-                </h1>
+                <Greeting firstName={profile.first_name} />
                 <p className="text-sm text-muted-foreground mt-0.5">
                   Welcome to your resume dashboard
                 </p>

--- a/src/components/dashboard/greeting.tsx
+++ b/src/components/dashboard/greeting.tsx
@@ -1,0 +1,22 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { getGreeting } from '@/lib/utils';
+
+interface GreetingProps {
+  firstName: string | null;
+}
+
+export function Greeting({ firstName }: GreetingProps) {
+  const [greeting, setGreeting] = useState('Welcome back');
+
+  useEffect(() => {
+    setGreeting(getGreeting());
+  }, []);
+
+  return (
+    <h1 className="text-2xl font-semibold bg-gradient-to-r from-teal-600 to-cyan-600 bg-clip-text text-transparent">
+      {greeting}, {firstName}
+    </h1>
+  );
+}


### PR DESCRIPTION
## What changed

- Render a deterministic dashboard greeting placeholder during SSR and hydration.
- Update the greeting to the user’s local time after the component mounts.

## Why

Authenticated production smoke testing found React hydration error #418 on `/home`. The server and browser were calling `new Date().getHours()` in different time zones, so the greeting could differ during hydration.

## Validation

- `pnpm test` — 87 passing
- `pnpm typecheck`
- `pnpm lint`
- `pnpm check:trust`
- `pnpm build` with placeholder non-secret environment values