### PR TITLE
Stabilize resume preview date hydration

### DIFF
--- a/src/components/resume/shared/mini-resume-preview.tsx
+++ b/src/components/resume/shared/mini-resume-preview.tsx
@@ -22,6 +22,7 @@ export function MiniResumePreview({
     if (!dateString) return '';
     const date = new Date(dateString);
     return date.toLocaleDateString('en-US', {
+      timeZone: 'UTC',
       month: '2-digit',
       day: '2-digit',
       year: 'numeric'
@@ -154,4 +155,4 @@ export function MiniResumePreview({
       )} />
     </div>
   );
-} 
+}


### PR DESCRIPTION
## What changed

- Format the mini resume preview date with an explicit UTC timezone.

## Why

Authenticated production smoke testing still found React hydration error #418 after the greeting fix. The resume preview card was formatting the same ISO timestamp in different server and browser time zones.

## Validation

- `pnpm test` — 87 passing
- `pnpm typecheck`
- `pnpm lint`
- `pnpm check:trust`
- `pnpm build` with placeholder non-secret environment values