### PR TITLE
Repair funnel identity and attribution tracking

### DIFF
--- a/src/app/(auth)/auth/callback/route.ts
+++ b/src/app/(auth)/auth/callback/route.ts
@@ -1,5 +1,7 @@
 import { createServerClient, type CookieOptions } from '@supabase/ssr'
 import { NextRequest, NextResponse } from 'next/server'
+import { AnalyticsEvents } from '@/lib/analytics/events'
+import { captureServerAnalyticsEvent } from '@/lib/analytics/server'
 
 import {
   AUTH_ERROR_CODES,
@@ -44,6 +46,22 @@ function redirectToLogin(
 
 function logCallbackFailure(details: Record<string, unknown>) {
   console.error('Google OAuth callback failed:', details)
+}
+
+function isNewOAuthUser(user: {
+  created_at?: string
+  last_sign_in_at?: string | null
+}) {
+  const createdAt = Date.parse(user.created_at ?? '')
+  const lastSignInAt = Date.parse(user.last_sign_in_at ?? '')
+  const now = Date.now()
+
+  return (
+    Number.isFinite(createdAt) &&
+    Number.isFinite(lastSignInAt) &&
+    now - createdAt <= 15 * 60 * 1000 &&
+    Math.abs(lastSignInAt - createdAt) <= 2 * 60 * 1000
+  )
 }
 
 export async function GET(request: NextRequest) {
@@ -139,6 +157,17 @@ export async function GET(request: NextRequest) {
       plan: intent.plan ?? null,
     })
     return redirectToLogin(requestUrl, intent, errorCode, pendingCookies, pendingHeaders)
+  }
+
+  const oauthUser = exchangeResult.data.session?.user
+  if (oauthUser && isNewOAuthUser(oauthUser)) {
+    await captureServerAnalyticsEvent({
+      distinctId: oauthUser.id,
+      event: AnalyticsEvents.SignupCompleted,
+      properties: {
+        signup_provider: 'google',
+      },
+    })
   }
 
   const redirectPath = getAuthRedirectPath(intent)

--- a/src/app/(dashboard)/layout.tsx
+++ b/src/app/(dashboard)/layout.tsx
@@ -66,7 +66,7 @@ export default async function DashboardLayout({
       }}
     >
       <Suspense fallback={null}>
-        <PostHogPageView />
+        <PostHogPageView userId={user.id} />
         <PagePerformance />
       </Suspense>
       {impersonationState && (

--- a/src/app/(dashboard)/subscription/checkout-return/route.ts
+++ b/src/app/(dashboard)/subscription/checkout-return/route.ts
@@ -6,7 +6,19 @@ import Stripe from "stripe";
 
 
 const apiKey = process.env.STRIPE_SECRET_KEY as string;
-const stripe = new Stripe(apiKey);
+let stripe: Stripe | null = null;
+
+function getStripe(): Stripe {
+  if (!stripe) {
+    if (!apiKey) {
+      throw new Error('STRIPE_SECRET_KEY is not configured. Stripe features are disabled.');
+    }
+
+    stripe = new Stripe(apiKey);
+  }
+
+  return stripe;
+}
 
 export const GET = async (request: NextRequest) => {
   const { searchParams } = new URL(request.url);
@@ -17,7 +29,7 @@ export const GET = async (request: NextRequest) => {
   if (!stripeSessionId?.length)
     return redirect("/home");
 
-  const session = await stripe.checkout.sessions.retrieve(stripeSessionId);
+  const session = await getStripe().checkout.sessions.retrieve(stripeSessionId);
 
   if (session.status === "complete") {
     return redirect(`/subscription/checkout/success?session_id=${stripeSessionId}`);

--- a/src/app/(dashboard)/subscription/stripe-session.tsx
+++ b/src/app/(dashboard)/subscription/stripe-session.tsx
@@ -2,6 +2,7 @@
 
 import { Stripe } from "stripe";
 import { checkAuth } from "@/app/(auth)/auth/login/actions";
+import { getServerAnalyticsContext } from "@/lib/analytics/server";
 import { createOrRetrieveCustomer } from "@/utils/actions/stripe/actions";
 import {
     buildCheckoutIdempotencyKey,
@@ -91,10 +92,12 @@ export const postStripeSession = async ({ priceId, includeTrial = false }: NewSe
             };
         }
 
+        const analyticsContext = await getServerAnalyticsContext();
         const checkoutMetadata = buildCheckoutSessionMetadata({
             userId: user.id,
             priceId,
             includeTrial,
+            analyticsContext,
         });
 
         const openSessions = await stripe.checkout.sessions.list({
@@ -152,6 +155,7 @@ export const postStripeSession = async ({ priceId, includeTrial = false }: NewSe
                     userId: user.id,
                     priceId,
                     includeTrial,
+                    analyticsContext,
                 }),
                 ...(includeTrial && {
                     trial_period_days: 7,

--- a/src/app/api/webhooks/stripe/route.ts
+++ b/src/app/api/webhooks/stripe/route.ts
@@ -7,6 +7,11 @@ import { createServiceClient } from '@/utils/supabase/server'
 import { AnalyticsEvents } from '@/lib/analytics/events'
 import { captureServerAnalyticsEvent } from '@/lib/analytics/server'
 import {
+  normalizeAnalyticsAnonymousId,
+  UTM_PARAMETER_NAMES,
+  type AnalyticsAttributionContext,
+} from '@/lib/analytics/attribution'
+import {
   getPaymentFailureRecoveryFields,
   getPaymentRecoveryClearedFields,
   getInvoiceSubscriptionId,
@@ -15,9 +20,21 @@ import {
 } from '@/lib/stripe/billing-events'
 import type { Subscription } from '@/lib/types'
 
-const stripe = new Stripe(process.env.STRIPE_SECRET_KEY!, {
-  apiVersion: '2025-04-30.basil'
-})
+let stripe: Stripe | null = null;
+
+function getStripe(): Stripe {
+  if (!stripe) {
+    if (!process.env.STRIPE_SECRET_KEY) {
+      throw new Error('STRIPE_SECRET_KEY is not configured. Stripe features are disabled.');
+    }
+
+    stripe = new Stripe(process.env.STRIPE_SECRET_KEY, {
+      apiVersion: '2025-04-30.basil'
+    });
+  }
+
+  return stripe;
+}
 
 const webhookSecret = process.env.STRIPE_WEBHOOK_SECRET!
 
@@ -173,6 +190,31 @@ function getSubscriptionEventProperties(
   };
 }
 
+function getStripeAnalyticsContext(
+  metadata: Stripe.Metadata | null | undefined,
+): AnalyticsAttributionContext {
+  const currentAttribution = Object.fromEntries(
+    UTM_PARAMETER_NAMES.flatMap((name) => {
+      const value = metadata?.[name];
+      return value ? [[name, value]] : [];
+    }),
+  );
+  const firstTouchAttribution = Object.fromEntries(
+    UTM_PARAMETER_NAMES.flatMap((name) => {
+      const value = metadata?.[`initial_${name}`];
+      return value ? [[name, value]] : [];
+    }),
+  );
+
+  return {
+    anonymousId: normalizeAnalyticsAnonymousId(
+      metadata?.analytics_anonymous_id,
+    ),
+    currentAttribution,
+    firstTouchAttribution,
+  };
+}
+
 async function captureTrialStartedEvent(input: {
   eventType: string;
   subscription: Stripe.Subscription;
@@ -196,6 +238,7 @@ async function captureTrialStartedEvent(input: {
     distinctId: userId,
     event: AnalyticsEvents.TrialStarted,
     insertId: `${input.subscription.id}:trial_started`,
+    context: getStripeAnalyticsContext(input.subscription.metadata),
     properties: {
       ...getSubscriptionEventProperties(input.subscriptionData, input.eventType),
       trial_start: input.subscription.trial_start
@@ -222,6 +265,7 @@ async function captureSubscriptionCanceledEvent(input: {
     distinctId: userId,
     event: AnalyticsEvents.SubscriptionCanceled,
     insertId: `${input.subscription.id}:subscription_canceled`,
+    context: getStripeAnalyticsContext(input.subscription.metadata),
     properties: {
       ...getSubscriptionEventProperties(input.subscriptionData, input.eventType),
       canceled_at: input.subscription.canceled_at
@@ -322,7 +366,7 @@ async function captureFirstInvoicePaidEvent(input: {
 
   let paidSubscriptionInvoices: Stripe.Invoice[];
   try {
-    const invoices = await stripe.invoices.list({
+    const invoices = await getStripe().invoices.list({
       subscription: input.subscriptionId,
       status: 'paid',
       limit: 100,
@@ -393,7 +437,7 @@ export async function POST(req: Request) {
     let event: Stripe.Event
     try {
       console.log('🔍 Verifying webhook signature...');
-      event = stripe.webhooks.constructEvent(body, signature, webhookSecret)
+      event = getStripe().webhooks.constructEvent(body, signature, webhookSecret)
       console.log('✅ Webhook signature verified successfully');
     } catch (err: unknown) {
       const error = err as Error
@@ -457,6 +501,7 @@ export async function POST(req: Request) {
               distinctId: subscriptionData.user_id,
               event: AnalyticsEvents.CheckoutCompleted,
               insertId: `${event.id}:checkout_completed`,
+              context: getStripeAnalyticsContext(session.metadata),
               properties: {
                 ...getSubscriptionEventProperties(subscriptionData, event.type),
                 stripe_checkout_session_id: session.id,

--- a/src/components/analytics/posthog-pageview.tsx
+++ b/src/components/analytics/posthog-pageview.tsx
@@ -7,17 +7,20 @@ import {
   getAttributionProperties,
   getBrowserStorage,
   getUtmParameters,
+  getAnalyticsContextProperties,
+  persistBrowserAnalyticsContext,
   persistFirstTouchAttribution,
+  readBrowserAnalyticsAnonymousId,
   sanitizeAnalyticsUrl,
 } from '@/lib/analytics/attribution';
 
-export function PostHogPageView() {
+export function PostHogPageView({ userId }: { userId?: string | null }) {
   const pathname = usePathname();
   const searchParams = useSearchParams();
   const posthog = usePostHog();
 
   useEffect(() => {
-    if (!posthog || !pathname) return;
+    if (!pathname) return;
 
     const search = searchParams.toString();
     const currentUrl =
@@ -34,16 +37,30 @@ export function PostHogPageView() {
       currentAttribution,
       firstTouchAttribution,
     );
+    const anonymousId =
+      readBrowserAnalyticsAnonymousId() ??
+      (!userId ? posthog?.get_distinct_id?.() : undefined);
+    const analyticsContext = {
+      anonymousId,
+      currentAttribution,
+      firstTouchAttribution,
+    };
+    const contextProperties = getAnalyticsContextProperties(analyticsContext);
 
-    if (Object.keys(attribution).length > 0) {
-      posthog.register(attribution);
+    persistBrowserAnalyticsContext(analyticsContext);
+
+    if (!posthog) return;
+
+    if (Object.keys(contextProperties).length > 0) {
+      posthog.register(contextProperties);
     }
 
     posthog.capture('$pageview', {
       $current_url: sanitizeAnalyticsUrl(currentUrl),
       ...attribution,
+      ...contextProperties,
     });
-  }, [pathname, posthog, searchParams]);
+  }, [pathname, posthog, searchParams, userId]);
 
   return null;
 }

--- a/src/components/analytics/posthog-provider.tsx
+++ b/src/components/analytics/posthog-provider.tsx
@@ -4,6 +4,7 @@ import { useEffect } from 'react';
 import posthog from 'posthog-js';
 import { PostHogProvider as PostHogReactProvider } from 'posthog-js/react';
 import { sanitizeAnalyticsProperties } from '@/lib/analytics/events';
+import { readBrowserAnalyticsAnonymousId } from '@/lib/analytics/attribution';
 import { OutboundLinkTracker } from './outbound-link-tracker';
 
 const posthogKey = process.env.NEXT_PUBLIC_POSTHOG_KEY;
@@ -56,14 +57,19 @@ export function PostHogProvider({
     // Supabase user IDs are the canonical identity for both browser and
     // server-side events. Keeping this call in the shared provider means the
     // checkout/editor events cannot accidentally stay on an anonymous ID.
+    const anonymousId = readBrowserAnalyticsAnonymousId();
     posthog.identify(user.id, sanitizeAnalyticsProperties({
       subscription_plan: user.subscriptionPlan,
       subscription_status: user.subscriptionStatus,
       is_pro: user.isPro,
+      analytics_anonymous_id: anonymousId,
+      analytics_user_id: user.id,
     }));
     activeIdentifiedUserId = user.id;
     posthog.register({
       analytics_identity: user.id,
+      analytics_user_id: user.id,
+      ...(anonymousId ? { analytics_anonymous_id: anonymousId } : {}),
     });
   }, [user?.id, user?.isPro, user?.subscriptionPlan, user?.subscriptionStatus]);
 

--- a/src/lib/analytics/attribution.test.ts
+++ b/src/lib/analytics/attribution.test.ts
@@ -2,8 +2,11 @@ import assert from "node:assert/strict";
 import { describe, it } from "node:test";
 
 import {
+  getAnalyticsContextProperties,
   getAttributionProperties,
   getUtmParameters,
+  normalizeAnalyticsAnonymousId,
+  parseStoredAttributionValue,
   persistFirstTouchAttribution,
   sanitizeAnalyticsUrl,
   withUtmParameters,
@@ -22,6 +25,31 @@ function createStorage(initial: Record<string, string> = {}) {
 }
 
 describe("analytics attribution", () => {
+  it("accepts a safe stable anonymous ID and rejects unsafe values", () => {
+    assert.equal(normalizeAnalyticsAnonymousId("ph_anon-123"), "ph_anon-123");
+    assert.equal(normalizeAnalyticsAnonymousId("anon id"), undefined);
+    assert.equal(normalizeAnalyticsAnonymousId(""), undefined);
+  });
+
+  it("parses the encoded first-touch cookie payload", () => {
+    assert.deepEqual(
+      parseStoredAttributionValue(
+        encodeURIComponent(
+          JSON.stringify({
+            utm_source: "github",
+            utm_medium: "referral",
+            ignored: "value",
+          }),
+        ),
+      ),
+      { utm_source: "github", utm_medium: "referral" },
+    );
+    assert.deepEqual(
+      parseStoredAttributionValue('{"utm_source":"100%organic"}'),
+      { utm_source: "100%organic" },
+    );
+  });
+
   it("reads and bounds UTM parameters", () => {
     const result = getUtmParameters(
       "https://resumelm.ca/?utm_source=github&utm_medium=referral&ignored=value&utm_campaign=${" + "a".repeat(200) + "}",
@@ -58,6 +86,23 @@ describe("analytics attribution", () => {
         utm_source: "linkedin",
         initial_utm_source: "github",
         utm_medium: "social",
+        initial_utm_medium: "referral",
+      },
+    );
+  });
+
+  it("adds the stable anonymous ID alongside current and first-touch UTM values", () => {
+    assert.deepEqual(
+      getAnalyticsContextProperties({
+        anonymousId: "ph_anon-123",
+        currentAttribution: { utm_source: "resumelm", utm_medium: "referral" },
+        firstTouchAttribution: { utm_source: "github", utm_medium: "referral" },
+      }),
+      {
+        analytics_anonymous_id: "ph_anon-123",
+        utm_source: "resumelm",
+        initial_utm_source: "github",
+        utm_medium: "referral",
         initial_utm_medium: "referral",
       },
     );

--- a/src/lib/analytics/attribution.ts
+++ b/src/lib/analytics/attribution.ts
@@ -10,6 +10,16 @@ export type UtmParameterName = (typeof UTM_PARAMETER_NAMES)[number];
 export type UtmParameters = Partial<Record<UtmParameterName, string>>;
 
 export const ATTRIBUTION_STORAGE_KEY = "resumelm:attribution";
+export const ANALYTICS_ANONYMOUS_ID_COOKIE = "resumelm:analytics-anonymous-id";
+export const ATTRIBUTION_COOKIE = "resumelm:attribution";
+export const LATEST_ATTRIBUTION_COOKIE = "resumelm:attribution-latest";
+export const ANALYTICS_COOKIE_MAX_AGE_SECONDS = 60 * 60 * 24 * 180;
+
+export interface AnalyticsAttributionContext {
+  anonymousId?: string;
+  currentAttribution: UtmParameters;
+  firstTouchAttribution: UtmParameters;
+}
 
 const MAX_VALUE_LENGTH = 120;
 const SENSITIVE_QUERY_PARAMETERS = new Set([
@@ -37,6 +47,36 @@ function normalizeValue(value: string | null): string | undefined {
   return normalized ? normalized.slice(0, MAX_VALUE_LENGTH) : undefined;
 }
 
+export function normalizeAnalyticsAnonymousId(value: string | null | undefined): string | undefined {
+  const normalized = value?.trim();
+  if (!normalized || normalized.length > MAX_VALUE_LENGTH) return undefined;
+
+  return /^[a-zA-Z0-9._:-]+$/.test(normalized) ? normalized : undefined;
+}
+
+export function parseStoredAttributionValue(value: string | null | undefined): UtmParameters {
+  if (!value) return {};
+
+  try {
+    let decoded = value;
+    try {
+      decoded = decodeURIComponent(value);
+    } catch {
+      // Cookie stores may already return a decoded value.
+    }
+    const parsed = JSON.parse(decoded) as Record<string, unknown>;
+    return Object.fromEntries(
+      UTM_PARAMETER_NAMES.flatMap((name) => {
+        const candidate = typeof parsed[name] === "string" ? parsed[name] : null;
+        const normalized = normalizeValue(candidate);
+        return normalized ? [[name, normalized]] : [];
+      }),
+    ) as UtmParameters;
+  } catch {
+    return {};
+  }
+}
+
 export function getUtmParameters(input: URLSearchParams | URL | string): UtmParameters {
   const searchParams =
     input instanceof URLSearchParams
@@ -58,14 +98,7 @@ export function readStoredAttribution(storage: Pick<Storage, "getItem"> | null):
     const value = storage.getItem(ATTRIBUTION_STORAGE_KEY);
     if (!value) return {};
 
-    const parsed = JSON.parse(value) as Record<string, unknown>;
-    return Object.fromEntries(
-      UTM_PARAMETER_NAMES.flatMap((name) => {
-        const candidate = typeof parsed[name] === "string" ? parsed[name] : null;
-        const normalized = normalizeValue(candidate);
-        return normalized ? [[name, normalized]] : [];
-      }),
-    ) as UtmParameters;
+    return parseStoredAttributionValue(value);
   } catch {
     return {};
   }
@@ -104,6 +137,72 @@ export function getAttributionProperties(
   }
 
   return properties;
+}
+
+export function getAnalyticsContextProperties(
+  context: AnalyticsAttributionContext,
+): Record<string, string> {
+  return {
+    ...(context.anonymousId
+      ? { analytics_anonymous_id: context.anonymousId }
+      : {}),
+    ...getAttributionProperties(
+      context.currentAttribution,
+      context.firstTouchAttribution,
+    ),
+  };
+}
+
+function setBrowserCookie(name: string, value: string): void {
+  if (typeof document === "undefined") return;
+
+  const secure = window.location.protocol === "https:" ? "; Secure" : "";
+  document.cookie = `${name}=${encodeURIComponent(value)}; Max-Age=${ANALYTICS_COOKIE_MAX_AGE_SECONDS}; Path=/; SameSite=Lax${secure}`;
+}
+
+export function persistBrowserAnalyticsContext(
+  context: AnalyticsAttributionContext,
+): void {
+  if (typeof document === "undefined") return;
+
+  if (context.anonymousId) {
+    setBrowserCookie(ANALYTICS_ANONYMOUS_ID_COOKIE, context.anonymousId);
+  }
+
+  if (Object.keys(context.firstTouchAttribution).length > 0) {
+    setBrowserCookie(
+      ATTRIBUTION_COOKIE,
+      JSON.stringify(context.firstTouchAttribution),
+    );
+  }
+
+  if (Object.keys(context.currentAttribution).length > 0) {
+    setBrowserCookie(
+      LATEST_ATTRIBUTION_COOKIE,
+      JSON.stringify(context.currentAttribution),
+    );
+  }
+}
+
+export function readBrowserAnalyticsAnonymousId(): string | undefined {
+  if (typeof document === "undefined") return undefined;
+
+  const cookie = document.cookie
+    .split(";")
+    .map((part) => part.trim())
+    .find((part) => part.startsWith(`${ANALYTICS_ANONYMOUS_ID_COOKIE}=`));
+
+  try {
+    return normalizeAnalyticsAnonymousId(
+      cookie
+        ? decodeURIComponent(
+            cookie.slice(ANALYTICS_ANONYMOUS_ID_COOKIE.length + 1),
+          )
+        : undefined,
+    );
+  } catch {
+    return undefined;
+  }
 }
 
 export function withUtmParameters(

--- a/src/lib/analytics/events.test.ts
+++ b/src/lib/analytics/events.test.ts
@@ -10,6 +10,7 @@ import {
 describe("AnalyticsEvents", () => {
   it("defines the operational lifecycle events used by product and billing analytics", () => {
     assert.equal(AnalyticsEvents.SignupCompleted, "signup_completed");
+    assert.equal(AnalyticsEvents.OnboardingCompleted, "onboarding_completed");
     assert.equal(AnalyticsEvents.ProfileCreated, "profile_created");
     assert.equal(AnalyticsEvents.ResumeCreated, "resume_created");
     assert.equal(AnalyticsEvents.ResumeTailored, "resume_tailored");

--- a/src/lib/analytics/events.ts
+++ b/src/lib/analytics/events.ts
@@ -1,5 +1,6 @@
 export const AnalyticsEvents = {
   SignupCompleted: "signup_completed",
+  OnboardingCompleted: "onboarding_completed",
   ProfileCreated: "profile_created",
   ResumeCreated: "resume_created",
   ResumeTailored: "resume_tailored",

--- a/src/lib/analytics/server.ts
+++ b/src/lib/analytics/server.ts
@@ -1,4 +1,5 @@
 import type { SupabaseClient } from "@supabase/supabase-js";
+import { cookies } from "next/headers";
 
 import { getSubscriptionAccessState } from "@/lib/subscription-access";
 import {
@@ -6,6 +7,15 @@ import {
   type AnalyticsEventName,
   type AnalyticsProperties,
 } from "./events";
+import {
+  ANALYTICS_ANONYMOUS_ID_COOKIE,
+  ATTRIBUTION_COOKIE,
+  getAnalyticsContextProperties,
+  LATEST_ATTRIBUTION_COOKIE,
+  normalizeAnalyticsAnonymousId,
+  parseStoredAttributionValue,
+  type AnalyticsAttributionContext,
+} from "./attribution";
 
 const posthogKey = process.env.NEXT_PUBLIC_POSTHOG_KEY;
 const posthogHost = process.env.NEXT_PUBLIC_POSTHOG_HOST ?? "https://us.i.posthog.com";
@@ -14,16 +24,46 @@ function getCaptureUrl() {
   return `${posthogHost.replace(/\/$/, "")}/capture/`;
 }
 
+export async function getServerAnalyticsContext(): Promise<AnalyticsAttributionContext> {
+  try {
+    const cookieStore = await cookies();
+    return {
+      anonymousId: normalizeAnalyticsAnonymousId(
+        cookieStore.get(ANALYTICS_ANONYMOUS_ID_COOKIE)?.value,
+      ),
+      currentAttribution: parseStoredAttributionValue(
+        cookieStore.get(LATEST_ATTRIBUTION_COOKIE)?.value,
+      ),
+      firstTouchAttribution: parseStoredAttributionValue(
+        cookieStore.get(ATTRIBUTION_COOKIE)?.value,
+      ),
+    };
+  } catch {
+    // Webhooks and non-request server contexts have no browser cookies.
+    return { currentAttribution: {}, firstTouchAttribution: {} };
+  }
+}
+
 export async function captureServerAnalyticsEvent(input: {
   distinctId: string | null | undefined;
   event: AnalyticsEventName;
   insertId?: string;
   properties?: AnalyticsProperties;
+  context?: Partial<AnalyticsAttributionContext>;
 }) {
   const distinctId = input.distinctId?.trim();
   if (!posthogKey || !distinctId) return;
 
   try {
+    const cookieContext = await getServerAnalyticsContext();
+    const context: AnalyticsAttributionContext = {
+      anonymousId: input.context?.anonymousId ?? cookieContext.anonymousId,
+      currentAttribution:
+        input.context?.currentAttribution ?? cookieContext.currentAttribution,
+      firstTouchAttribution:
+        input.context?.firstTouchAttribution ?? cookieContext.firstTouchAttribution,
+    };
+
     const response = await fetch(getCaptureUrl(), {
       method: "POST",
       headers: {
@@ -37,6 +77,8 @@ export async function captureServerAnalyticsEvent(input: {
           insertId: input.insertId,
           properties: {
             ...input.properties,
+            ...getAnalyticsContextProperties(context),
+            analytics_user_id: distinctId,
             capture_source: "server",
             identity_source: "supabase_user_id",
           },

--- a/src/lib/stripe/checkout-guard.test.ts
+++ b/src/lib/stripe/checkout-guard.test.ts
@@ -38,6 +38,29 @@ describe("buildCheckoutSessionMetadata", () => {
       source: "resumelm_checkout",
     });
   });
+
+  it("carries analytics identity and attribution into Stripe metadata", () => {
+    const metadata = buildCheckoutSessionMetadata({
+      userId: "user_123",
+      priceId: "price_pro",
+      includeTrial: true,
+      analyticsContext: {
+        anonymousId: "ph_anon-123",
+        currentAttribution: {
+          utm_source: "resumelm",
+          utm_medium: "referral",
+        },
+        firstTouchAttribution: {
+          utm_source: "github",
+          utm_medium: "referral",
+        },
+      },
+    });
+
+    assert.equal(metadata.analytics_anonymous_id, "ph_anon-123");
+    assert.equal(metadata.utm_source, "resumelm");
+    assert.equal(metadata.initial_utm_source, "github");
+  });
 });
 
 describe("buildSubscriptionMetadata", () => {

--- a/src/lib/stripe/checkout-guard.ts
+++ b/src/lib/stripe/checkout-guard.ts
@@ -1,4 +1,8 @@
 import type Stripe from "stripe";
+import {
+  getAnalyticsContextProperties,
+  type AnalyticsAttributionContext,
+} from "@/lib/analytics/attribution";
 
 const CHECKOUT_SOURCE = "resumelm_checkout";
 
@@ -6,9 +10,10 @@ export interface CheckoutGuardInput {
   userId: string;
   priceId: string;
   includeTrial: boolean;
+  analyticsContext?: AnalyticsAttributionContext;
 }
 
-export type CheckoutSessionMetadata = {
+export type CheckoutSessionMetadata = Record<string, string> & {
   supabaseUUID: string;
   price_id: string;
   include_trial: "true" | "false";
@@ -31,12 +36,16 @@ export function buildCheckoutSessionMetadata({
   userId,
   priceId,
   includeTrial,
+  analyticsContext,
 }: CheckoutGuardInput): CheckoutSessionMetadata {
   return {
     supabaseUUID: userId,
     price_id: priceId,
     include_trial: includeTrial ? "true" : "false",
     source: CHECKOUT_SOURCE,
+    ...(analyticsContext
+      ? getAnalyticsContextProperties(analyticsContext)
+      : {}),
   };
 }
 

--- a/src/utils/actions/profiles/actions.ts
+++ b/src/utils/actions/profiles/actions.ts
@@ -41,7 +41,7 @@ export async function updateProfile(data: Partial<Profile>): Promise<Profile> {
   if (!isProfileComplete(currentProfile) && isProfileComplete(profile)) {
     await captureServerAnalyticsEvent({
       distinctId: user.id,
-      event: AnalyticsEvents.ProfileCreated,
+      event: AnalyticsEvents.OnboardingCompleted,
       properties: await getSubscriptionAnalyticsProperties(supabase, user.id),
     });
   }
@@ -120,6 +120,14 @@ export async function importResume(data: Partial<Profile>): Promise<Profile> {
 
   if (error) {
     throw new Error(`Failed to update profile: ${error.message}`);
+  }
+
+  if (!isProfileComplete(currentProfile) && isProfileComplete(profile)) {
+    await captureServerAnalyticsEvent({
+      distinctId: user.id,
+      event: AnalyticsEvents.OnboardingCompleted,
+      properties: await getSubscriptionAnalyticsProperties(supabase, user.id),
+    });
   }
 
   // Revalidate all routes that might display profile data


### PR DESCRIPTION
## What changed

- Persist the PostHog anonymous ID and first/latest UTM attribution in first-party cookies.
- Add the shared identity and attribution context to browser and server-side PostHog events.
- Add explicit `analytics_user_id` and `analytics_anonymous_id` fields for reliable funnel analysis.
- Track a canonical `onboarding_completed` event for both profile editing and resume import completion.
- Capture Google OAuth signups in addition to email signups.
- Carry analytics identity and attribution into Stripe Checkout and subscription metadata so webhook lifecycle events retain source context.
- Lazily initialize Stripe in checkout-return and webhook routes so builds work without Stripe secrets.

## Why

Browser pageviews had UTM data, but server actions and Stripe webhooks could not see the browser's anonymous identity or attribution. That split signup, onboarding, resume creation, tailoring, and checkout across unrelated people and sources in PostHog.

## Validation

- `pnpm test` — 91 passing tests
- `pnpm typecheck`
- `pnpm lint`
- `pnpm check:trust`
- `pnpm build`
- Synthetic local PostHog capture verified the same anonymous ID persisted from landing to login while current UTM values changed and `initial_utm_*` remained stable.

## Scope note

Pre-existing untracked local demo fixtures were intentionally not included.