### PR TITLE
Optimize authenticated dashboard performance

### DIFF
--- a/src/app/(dashboard)/profile/page.tsx
+++ b/src/app/(dashboard)/profile/page.tsx
@@ -1,5 +1,5 @@
 import { redirect } from "next/navigation";
-import { getDashboardData } from "@/utils/actions";
+import { getProfilePageData } from "@/utils/actions";
 import { ProfileEditForm } from "@/components/profile/profile-edit-form";
 import { Suspense } from "react";
 
@@ -8,16 +8,15 @@ export const dynamic = 'force-dynamic';
 export const revalidate = 0;
 
 export default async function EditProfilePage() {
-  // Fetch profile data and handle authentication
-  let data;
+  // Fetch only the profile required by this route. The dashboard layout's
+  // request-scoped auth cache prevents a second Supabase auth lookup.
+  let profile;
   try {
-    data = await getDashboardData();
+    ({ profile } = await getProfilePageData());
   } catch (error: unknown) {
     void error
     redirect("/");
   }
-
-  const { profile } = data;
 
   // Display a friendly message if no profile exists
   if (!profile) {
@@ -42,4 +41,4 @@ export default async function EditProfilePage() {
       </div>
     </main>
   );
-} 
+}

--- a/src/app/(dashboard)/resumes/page.tsx
+++ b/src/app/(dashboard)/resumes/page.tsx
@@ -1,4 +1,4 @@
-import { getDashboardData } from "@/utils/actions";
+import { getResumesPageData } from "@/utils/actions";
 import { Suspense } from "react";
 import { Skeleton } from "@/components/ui/skeleton";
 import Link from "next/link";
@@ -19,34 +19,18 @@ export default async function ResumesPage({
 }) {
   const params = await searchParams;
   
-  const { baseResumes, tailoredResumes } = await getDashboardData();
-  
-  // Combine and sort resumes
-  const allResumes = [...baseResumes, ...tailoredResumes];
   const currentPage = Number(params.page) || 1;
-  const sort = (params.sort as SortOption) || 'createdAt';
-  const direction = (params.direction as SortDirection) || 'desc';
-
-  // Sort resumes
-  const sortedResumes = allResumes.sort((a, b) => {
-    const modifier = direction === 'asc' ? 1 : -1;
-    switch (sort) {
-      case 'name':
-        return modifier * a.name.localeCompare(b.name);
-      case 'jobTitle':
-        return modifier * (a.target_role?.localeCompare(b.target_role || '') || 0);
-      case 'createdAt':
-      default:
-        return modifier * (new Date(a.created_at).getTime() - new Date(b.created_at).getTime());
-    }
+  const sort: SortOption = params.sort === 'name' || params.sort === 'jobTitle' || params.sort === 'createdAt'
+    ? params.sort
+    : 'createdAt';
+  const direction: SortDirection = params.direction === 'asc' ? 'asc' : 'desc';
+  const { resumes, totalCount } = await getResumesPageData({
+    page: currentPage,
+    pageSize: RESUMES_PER_PAGE,
+    sort,
+    direction,
   });
-
-  // Paginate resumes
-  const totalPages = Math.ceil(sortedResumes.length / RESUMES_PER_PAGE);
-  const paginatedResumes = sortedResumes.slice(
-    (currentPage - 1) * RESUMES_PER_PAGE,
-    currentPage * RESUMES_PER_PAGE
-  );
+  const totalPages = Math.ceil(totalCount / RESUMES_PER_PAGE);
 
   return (
     <div className="min-h-screen bg-gradient-to-br from-rose-50/50 via-sky-50/50 to-violet-50/50">
@@ -70,6 +54,7 @@ export default async function ResumesPage({
             </Suspense>
             <Link
               href="/resumes/new"
+              prefetch={false}
               className={cn(
                 "inline-flex items-center justify-center",
                 "rounded-full text-sm font-medium",
@@ -89,8 +74,8 @@ export default async function ResumesPage({
         <div className="relative rounded-2xl overflow-hidden backdrop-blur-xl bg-white/40 border border-purple-200/50 shadow-xl">
           <Suspense fallback={<ResumesLoadingSkeleton />}>
             <div className="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-6 p-6">
-              {paginatedResumes.map((resume) => (
-                <Link href={`/resumes/${resume.id}`} key={resume.id}>
+              {resumes.map((resume) => (
+                <Link href={`/resumes/${resume.id}`} prefetch={false} key={resume.id}>
                   <MiniResumePreview
                     name={resume.name}
                     type={resume.is_base_resume ? 'base' : 'tailored'}
@@ -111,6 +96,7 @@ export default async function ResumesPage({
               <Link
                 key={i}
                 href={`?page=${i + 1}&sort=${sort}&direction=${direction}`}
+                prefetch={false}
                 className={cn(
                   "px-4 py-2 rounded-lg transition-colors",
                   currentPage === i + 1

--- a/src/app/(dashboard)/settings/page.tsx
+++ b/src/app/(dashboard)/settings/page.tsx
@@ -3,20 +3,15 @@
 "use server"
 
 import { SettingsContent } from '@/components/settings/settings-content'
-import { createClient } from '@/utils/supabase/server'
 import { getSubscriptionAccessState } from '@/lib/subscription-access';
+import { getAuthenticatedUser, getDashboardSubscription } from '@/utils/actions';
 
 
 export default async function SettingsPage() {
-  const supabase = await createClient();
-  const { data: { user } } = await supabase.auth.getUser();
+  const user = await getAuthenticatedUser();
 
   const { data: subscription } = user
-    ? await supabase
-        .from('subscriptions')
-        .select('subscription_plan, subscription_status, current_period_end, trial_end, stripe_subscription_id, payment_failure_count, last_payment_failed_at, next_payment_attempt_at')
-        .eq('user_id', user.id)
-        .maybeSingle()
+    ? await getDashboardSubscription(user.id)
     : { data: null };
 
   const subscriptionState = getSubscriptionAccessState(subscription);

--- a/src/components/dashboard/api-key-alert.tsx
+++ b/src/components/dashboard/api-key-alert.tsx
@@ -111,7 +111,7 @@ export function ApiKeyAlert({ variant = 'upgrade' }: { variant?: ApiKeyAlertVari
                       OpenAI <ArrowRight className="w-3 h-3" />
                     </a>
                   </div>
-                  <Link href="/settings">
+                  <Link href="/settings" prefetch={false}>
                     <Button
                       size="sm"
                       variant="ghost"

--- a/src/components/dashboard/profile-row.tsx
+++ b/src/components/dashboard/profile-row.tsx
@@ -15,7 +15,7 @@ export function ProfileRow({ profile }: ProfileRowProps) {
     <div className="group relative">
       {/* Animated background gradient */}
       <div className="absolute inset-0 bg-gradient-to-r from-purple-100/20 via-rose-100/20 to-teal-100/20 opacity-0 group-hover:opacity-100 transition-opacity duration-700 rounded-xl" />
-      
+
       <div className="relative rounded-xl bg-gradient-to-br from-white/60 to-white/30 hover:from-white/70 hover:to-white/40 backdrop-blur-xl border border-white/40 shadow-lg transition-all duration-500 group-hover:shadow-xl group-hover:-translate-y-0.5">
         <div className="px-4 sm:px-6 py-3">
           {/* Main container - stack on mobile, row on desktop */}
@@ -40,9 +40,9 @@ export function ProfileRow({ profile }: ProfileRowProps) {
               {/* Stats Row - hidden on mobile, visible on sm and up */}
               <div className="hidden sm:flex items-center gap-3">
                 {[
-                  { 
-                    icon: Briefcase, 
-                    label: "Experience", 
+                  {
+                    icon: Briefcase,
+                    label: "Experience",
                     count: profile.work_experience.length,
                     colors: {
                       bg: "from-cyan-50/50 to-cyan-100/50",
@@ -51,9 +51,9 @@ export function ProfileRow({ profile }: ProfileRowProps) {
                       border: "border-cyan-200"
                     }
                   },
-                  { 
-                    icon: GraduationCap, 
-                    label: "Education", 
+                  {
+                    icon: GraduationCap,
+                    label: "Education",
                     count: profile.education.length,
                     colors: {
                       bg: "from-indigo-50/50 to-indigo-100/50",
@@ -62,9 +62,9 @@ export function ProfileRow({ profile }: ProfileRowProps) {
                       border: "border-indigo-200"
                     }
                   },
-                  { 
-                    icon: Code, 
-                    label: "Projects", 
+                  {
+                    icon: Code,
+                    label: "Projects",
                     count: profile.projects.length,
                     colors: {
                       bg: "from-violet-50/50 to-violet-100/50",
@@ -74,8 +74,8 @@ export function ProfileRow({ profile }: ProfileRowProps) {
                     }
                   },
                 ].map((stat) => (
-                  <div 
-                    key={stat.label} 
+                  <div
+                    key={stat.label}
                     className={cn(
                       "flex items-center gap-2 px-2.5 py-1 rounded-full",
                       "bg-gradient-to-r border backdrop-blur-sm",
@@ -102,11 +102,11 @@ export function ProfileRow({ profile }: ProfileRowProps) {
             </div>
 
             {/* Edit Button with enhanced styling */}
-            <Link href="/profile" className="shrink-0">  
+            <Link href="/profile" prefetch={false} className="shrink-0">
               <Button
                 variant="outline"
                 size="sm"
-                className="w-full sm:w-auto bg-gradient-to-r from-teal-50 to-cyan-50 border-teal-200 hover:border-teal-300 text-teal-700 
+                className="w-full sm:w-auto bg-gradient-to-r from-teal-50 to-cyan-50 border-teal-200 hover:border-teal-300 text-teal-700
                            hover:bg-gradient-to-r hover:from-teal-100 hover:to-cyan-100
                            transition-all duration-500 hover:-translate-y-0.5 hover:shadow-md shadow-sm"
               >
@@ -119,4 +119,4 @@ export function ProfileRow({ profile }: ProfileRowProps) {
       </div>
     </div>
   );
-} 
+}

--- a/src/components/dashboard/resumes-section.tsx
+++ b/src/components/dashboard/resumes-section.tsx
@@ -256,6 +256,7 @@ export function ResumesSection({
   const LimitReachedCard = () => (
     <Link 
       href="/subscription"
+      prefetch={false}
       className={cn(
         "group/limit block",
         "cursor-pointer",
@@ -364,7 +365,7 @@ export function ResumesSection({
               </div>
             ) : (
               // Normal clickable resume
-              <Link href={`/resumes/${resume.id}`}>
+              <Link href={`/resumes/${resume.id}`} prefetch={false}>
                 <MiniResumePreview
                   name={resume.name}
                   type={type}
@@ -459,7 +460,7 @@ export function ResumesSection({
                       <AlertDialogFooter>
                         <AlertDialogCancel>Cancel</AlertDialogCancel>
                         <AlertDialogAction asChild>
-                          <Link href="/subscription" className="bg-gradient-to-r from-teal-600 to-cyan-600 text-white hover:from-teal-700 hover:to-cyan-700">
+                          <Link href="/subscription" prefetch={false} className="bg-gradient-to-r from-teal-600 to-cyan-600 text-white hover:from-teal-700 hover:to-cyan-700">
                             Upgrade to Pro
                           </Link>
                         </AlertDialogAction>

--- a/src/components/dashboard/welcome-dialog.tsx
+++ b/src/components/dashboard/welcome-dialog.tsx
@@ -22,8 +22,8 @@ export function WelcomeDialog({ isOpen: initialIsOpen }: WelcomeDialogProps) {
   }, [initialIsOpen]);
 
   return (
-    <Dialog 
-      open={isOpen} 
+    <Dialog
+      open={isOpen}
       onOpenChange={setIsOpen}
     >
       <DialogContent className="sm:max-w-md">
@@ -32,7 +32,7 @@ export function WelcomeDialog({ isOpen: initialIsOpen }: WelcomeDialogProps) {
             Welcome to ResumeLM! 🎉
           </DialogTitle>
         </DialogHeader>
-        
+
         <div className="pt-4 space-y-6">
           <h3 className="font-medium text-foreground">Here&apos;s how to get started:</h3>
           <div className="space-y-4">
@@ -62,13 +62,13 @@ export function WelcomeDialog({ isOpen: initialIsOpen }: WelcomeDialogProps) {
             </div>
           </div>
           <div className="pt-2 space-y-2">
-            <Link href="/profile">
+            <Link href="/profile" prefetch={false}>
               <Button className="w-full bg-gradient-to-r from-teal-600 to-cyan-600 text-white">
                 Start by Filling Your Profile
               </Button>
             </Link>
-            <Button 
-              variant="outline" 
+            <Button
+              variant="outline"
               className="w-full"
               onClick={() => setIsOpen(false)}
             >
@@ -79,4 +79,4 @@ export function WelcomeDialog({ isOpen: initialIsOpen }: WelcomeDialogProps) {
       </DialogContent>
     </Dialog>
   );
-} 
+}

--- a/src/components/layout/app-header.tsx
+++ b/src/components/layout/app-header.tsx
@@ -112,6 +112,7 @@ export function AppHeader({
                 <div className="flex items-center px-2 lg:px-3 py-1">
                   <Link 
                     href="/profile" 
+                    prefetch={false}
                     onClick={handleProfileClick}
                     className={cn(
                       "flex items-center gap-1.5 px-2 lg:px-3 py-1",
@@ -163,6 +164,7 @@ export function AppHeader({
                     
                     <Link
                       href="/profile"
+                      prefetch={false}
                       onClick={handleProfileClick}
                       className={cn(
                         "flex items-center gap-2 px-4 py-2 rounded-md",

--- a/src/components/resume/editor/actions/resume-editor-actions.tsx
+++ b/src/components/resume/editor/actions/resume-editor-actions.tsx
@@ -36,6 +36,7 @@ export function ResumeEditorActions({
     try {
       dispatch({ type: 'SET_SAVING', value: true });
       await updateResume(state.resume.id, state.resume);
+      dispatch({ type: 'MARK_SAVED' });
       toast({
         title: "Changes saved",
         description: "Your resume has been updated successfully.",

--- a/src/components/resume/editor/panels/preview-panel.tsx
+++ b/src/components/resume/editor/panels/preview-panel.tsx
@@ -9,6 +9,7 @@ import { ResumeContextMenu } from "../preview/resume-context-menu";
 import { Button } from "@/components/ui/button";
 import { Plus } from "lucide-react";
 import { LoadingFallback } from "../shared/LoadingFallback";
+import { useDeferredValue } from "react";
 
 const LazyCoverLetter = dynamic(() => import("@/components/cover-letter/cover-letter"), {
   ssr: false,
@@ -27,6 +28,10 @@ export function PreviewPanel({
   onResumeChange,
   width
 }: PreviewPanelProps) {
+  // Keep form updates immediate while allowing the heavier HTML preview to
+  // yield briefly during rapid typing in larger resumes.
+  const previewResume = useDeferredValue(resume);
+
   return (
     <ScrollArea className={cn(
       "z-50 h-full",
@@ -36,7 +41,7 @@ export function PreviewPanel({
     )}>
       <div className="">
       <ResumeContextMenu resume={resume}>
-          <ResumePreview resume={resume} containerWidth={width} />
+          <ResumePreview resume={previewResume} containerWidth={width} />
         </ResumeContextMenu>
       </div>
 

--- a/src/components/resume/editor/resume-editor-client.tsx
+++ b/src/components/resume/editor/resume-editor-client.tsx
@@ -2,7 +2,7 @@
 
 import React from 'react';
 import { Resume, Profile, Job } from "@/lib/types";
-import { useState, useEffect, useReducer } from "react";
+import { useState, useEffect, useReducer, useCallback } from "react";
 import { useRouter } from "next/navigation";
 import { ResumeContext, resumeReducer } from './resume-editor-context';
 import { createClient } from "@/utils/supabase/client";
@@ -99,7 +99,7 @@ export function ResumeEditorClient({
     };
   }, [state.resume.job_id, job?.id]);
 
-  const updateField = <K extends keyof Resume>(field: K, value: Resume[K]) => {
+  const updateField = useCallback(<K extends keyof Resume>(field: K, value: Resume[K]) => {
     
     if (field === 'document_settings') {
       // Ensure we're passing a valid DocumentSettings object
@@ -111,13 +111,7 @@ export function ResumeEditorClient({
     } else {
       dispatch({ type: 'UPDATE_FIELD', field, value });
     }
-  };
-
-  // Track changes
-  useEffect(() => {
-    const hasChanges = JSON.stringify(state.resume) !== JSON.stringify(initialResume);
-    dispatch({ type: 'SET_HAS_CHANGES', value: hasChanges });
-  }, [state.resume, initialResume]);
+  }, [dispatch]);
 
   // Handle beforeunload event
   useEffect(() => {

--- a/src/components/resume/editor/resume-editor-context.test.ts
+++ b/src/components/resume/editor/resume-editor-context.test.ts
@@ -1,0 +1,55 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+
+import type { Resume } from "@/lib/types";
+import { resumeReducer } from "./resume-editor-context";
+
+const resume = {
+  id: "resume-1",
+  user_id: "user-1",
+  name: "Test resume",
+  target_role: "Engineer",
+  is_base_resume: true,
+  first_name: "Alex",
+  last_name: "Example",
+  email: "alex@example.com",
+  work_experience: [],
+  education: [],
+  skills: [],
+  projects: [],
+  created_at: "2026-01-01T00:00:00.000Z",
+  updated_at: "2026-01-01T00:00:00.000Z",
+  has_cover_letter: false,
+} satisfies Resume;
+
+describe("resume editor dirty state", () => {
+  it("marks field updates dirty without serializing the whole resume", () => {
+    const state = {
+      resume,
+      isSaving: false,
+      isDeleting: false,
+      hasUnsavedChanges: false,
+    };
+
+    const updated = resumeReducer(state, {
+      type: "UPDATE_FIELD",
+      field: "name",
+      value: "Updated resume",
+    });
+
+    assert.equal(updated.resume.name, "Updated resume");
+    assert.equal(updated.hasUnsavedChanges, true);
+  });
+
+  it("clears dirty state after a successful save", () => {
+    const state = {
+      resume,
+      isSaving: false,
+      isDeleting: false,
+      hasUnsavedChanges: true,
+    };
+
+    const saved = resumeReducer(state, { type: "MARK_SAVED" });
+    assert.equal(saved.hasUnsavedChanges, false);
+  });
+});

--- a/src/components/resume/editor/resume-editor-context.tsx
+++ b/src/components/resume/editor/resume-editor-context.tsx
@@ -8,11 +8,11 @@ interface ResumeState {
   hasUnsavedChanges: boolean;
 }
 
-type ResumeAction = 
+type ResumeAction =
   | { type: 'UPDATE_FIELD'; field: keyof Resume; value: Resume[keyof Resume] }
   | { type: 'SET_SAVING'; value: boolean }
   | { type: 'SET_DELETING'; value: boolean }
-  | { type: 'SET_HAS_CHANGES'; value: boolean };
+  | { type: 'MARK_SAVED' };
 
 const ResumeContext = createContext<{
   state: ResumeState;
@@ -27,21 +27,21 @@ function resumeReducer(state: ResumeState, action: ResumeAction): ResumeState {
         resume: {
           ...state.resume,
           [action.field]: action.value
-        }
+        },
+        hasUnsavedChanges: true,
       };
       return newState;
 
 
-      
+
     case 'SET_SAVING':
       // console.log('Resume Editor Context - Saving State:', action.value);
       return { ...state, isSaving: action.value };
     case 'SET_DELETING':
       // console.log('Resume Editor Context - Deleting State:', action.value);
       return { ...state, isDeleting: action.value };
-    case 'SET_HAS_CHANGES':
-      // console.log('Resume Editor Context - Unsaved Changes:', action.value);
-      return { ...state, hasUnsavedChanges: action.value };
+    case 'MARK_SAVED':
+      return { ...state, hasUnsavedChanges: false };
     default:
       return state;
   }
@@ -55,4 +55,4 @@ export function useResumeContext() {
   return context;
 }
 
-export { ResumeContext, resumeReducer }; 
+export { ResumeContext, resumeReducer };

--- a/src/components/resume/management/cards/resume-list.tsx
+++ b/src/components/resume/management/cards/resume-list.tsx
@@ -36,6 +36,7 @@ export function ResumeList({
         <Link
           key={resume.id}
           href={`/resumes/${resume.id}`}
+          prefetch={false}
           className={cn(
             "group relative overflow-hidden rounded-lg border transition-all duration-300",
             "bg-white/50 hover:bg-white/60",

--- a/src/components/settings/pro-upgrade-button.tsx
+++ b/src/components/settings/pro-upgrade-button.tsx
@@ -19,12 +19,13 @@ export function ProUpgradeButton({ className }: ProUpgradeButtonProps) {
     >
       {/* Outer glow effect */}
       <div className="absolute -inset-[3px] bg-gradient-to-r from-amber-500/0 via-orange-500/0 to-red-500/0 rounded-lg opacity-75 blur-md group-hover:from-amber-500/50 group-hover:via-orange-500/50 group-hover:to-red-500/50 transition-all duration-300 ease-in-out" />
-      
+
       {/* Inner gradient */}
       <div className="absolute inset-0 bg-gradient-to-r from-amber-400/0 via-orange-400/0 to-red-400/0 rounded-lg opacity-100 group-hover:via-orange-400/10 transition-all duration-300 ease-in-out" />
-      
-      <Link 
-        href="/subscription" 
+
+      <Link
+        href="/subscription"
+        prefetch={false}
         className={cn(
           "relative flex items-center gap-1.5 px-4 py-1.5",
           "bg-gradient-to-r from-amber-500 to-orange-500",
@@ -41,4 +42,4 @@ export function ProUpgradeButton({ className }: ProUpgradeButtonProps) {
       </Link>
     </motion.div>
   );
-} 
+}

--- a/src/components/settings/settings-button.tsx
+++ b/src/components/settings/settings-button.tsx
@@ -17,6 +17,7 @@ export function SettingsButton({ className, onAllowedNavigation }: SettingsButto
   return (
     <Link 
       href="/settings" 
+      prefetch={false}
       onClick={handleClick}
       className={cn(
         "flex items-center gap-1.5 px-3 py-1",

--- a/src/components/shared/model-selector.tsx
+++ b/src/components/shared/model-selector.tsx
@@ -32,7 +32,7 @@ interface ModelSelectorProps {
 function UnavailableModelPopover({ children, model }: { children: React.ReactNode; model: AIModel }) {
   const [open, setOpen] = useState(false)
   const provider = getProviderById(model.provider)
-  
+
   return (
     <Popover open={open} onOpenChange={setOpen}>
       <PopoverTrigger asChild>
@@ -44,9 +44,9 @@ function UnavailableModelPopover({ children, model }: { children: React.ReactNod
           {children}
         </div>
       </PopoverTrigger>
-      <PopoverContent 
-        className="w-80 z-50" 
-        side="right" 
+      <PopoverContent
+        className="w-80 z-50"
+        side="right"
         align="start"
         onMouseEnter={() => setOpen(true)}
         onMouseLeave={() => setOpen(false)}
@@ -60,7 +60,7 @@ function UnavailableModelPopover({ children, model }: { children: React.ReactNod
               To use this model, you need either a Pro subscription or a {provider?.name} API key.
             </p>
           </div>
-          
+
           <div className="space-y-2">
             {/* Pro Option */}
             <div className="p-3 rounded-lg border border-purple-200/50 bg-gradient-to-br from-purple-50/50 to-purple-100/30">
@@ -74,7 +74,7 @@ function UnavailableModelPopover({ children, model }: { children: React.ReactNod
               <p className="text-xs text-purple-700 mb-2">
                 Get unlimited access to all AI models without managing API keys
               </p>
-              <Link href="/subscription">
+              <Link href="/subscription" prefetch={false}>
                 <Button size="sm" className="w-full bg-purple-600 hover:bg-purple-700 h-7 text-xs">
                   Upgrade to Pro
                 </Button>
@@ -90,7 +90,7 @@ function UnavailableModelPopover({ children, model }: { children: React.ReactNod
                 Add your own {provider?.name} API key to use this model
               </p>
               <div className="flex gap-2">
-                <Link href="/settings" className="flex-1">
+                <Link href="/settings" prefetch={false} className="flex-1">
                   <Button size="sm" variant="outline" className="w-full h-7 text-xs">
                     Configure API Key
                   </Button>
@@ -111,16 +111,16 @@ function UnavailableModelPopover({ children, model }: { children: React.ReactNod
   )
 }
 
-export function ModelSelector({ 
-  value, 
-  onValueChange, 
-  apiKeys, 
-  isProPlan, 
+export function ModelSelector({
+  value,
+  onValueChange,
+  apiKeys,
+  isProPlan,
   className,
   placeholder = "Select an AI model",
   showToast = true
 }: ModelSelectorProps) {
-  
+
   const isModelSelectable = (modelId: string) => {
     return isModelAvailable(modelId, isProPlan, apiKeys)
   }
@@ -176,10 +176,10 @@ export function ModelSelector({
               {group.models.map((model) => {
                 const provider = getProviderById(model.provider)
                 const isSelectable = isModelSelectable(model.id)
-                
+
                 const selectItem = (
-                  <SelectItem 
-                    key={model.id} 
+                  <SelectItem
+                    key={model.id}
                     value={model.id}
                     disabled={!isSelectable}
                     className={cn(
@@ -245,4 +245,4 @@ export function ModelSelector({
 }
 
 // Re-export types from centralized location
-export type { AIModel, ApiKey } from '@/lib/ai-models' 
+export type { AIModel, ApiKey } from '@/lib/ai-models'

--- a/src/components/trial/trial-start-button.tsx
+++ b/src/components/trial/trial-start-button.tsx
@@ -25,6 +25,7 @@ export function TrialStartButton({ className }: TrialStartButtonProps) {
 
       <Link
         href={href}
+        prefetch={false}
         className={cn(
           'relative flex items-center gap-1.5 px-4 py-1.5',
           'bg-gradient-to-r from-purple-600 to-indigo-600',
@@ -44,4 +45,3 @@ export function TrialStartButton({ className }: TrialStartButtonProps) {
     </motion.div>
   );
 }
-

--- a/src/utils/actions.ts
+++ b/src/utils/actions.ts
@@ -5,7 +5,7 @@ import { Profile, ResumeSummary } from "@/lib/types";
 import { getSubscriptionAccessState } from "@/lib/subscription-access";
 import { cache } from "react";
 
-interface DashboardData {
+export interface DashboardData {
   profile: Profile | null;
   baseResumes: ResumeSummary[];
   tailoredResumes: ResumeSummary[];
@@ -46,10 +46,38 @@ export const getDashboardSubscription = cache(async (userId: string) => {
   const supabase = await createClient();
   return supabase
     .from('subscriptions')
-    .select('subscription_plan, subscription_status, stripe_subscription_id, current_period_end, trial_end')
+    .select('subscription_plan, subscription_status, stripe_customer_id, stripe_subscription_id, current_period_end, trial_end, payment_failure_count, last_payment_failed_at, next_payment_attempt_at')
     .eq('user_id', userId)
     .maybeSingle();
 });
+
+// Keep profile reads request-scoped and share them between route loaders.
+// This deliberately uses a projection because profile rows contain large JSON
+// arrays that should not be fetched by routes that only need identity data.
+export const getProfileForUser = cache(async (userId: string) => {
+  const supabase = await createClient();
+  return supabase
+    .from('profiles')
+    .select('user_id, first_name, last_name, email, phone_number, location, website, linkedin_url, github_url, is_admin, work_experience, education, skills, projects, certifications, created_at, updated_at')
+    .eq('user_id', userId)
+    .maybeSingle();
+});
+
+export async function getProfilePageData() {
+  const user = await getAuthenticatedUser();
+
+  if (!user) {
+    return { user: null, profile: null };
+  }
+
+  const { data, error } = await getProfileForUser(user.id);
+  if (error) {
+    throw new Error('Error fetching profile data');
+  }
+
+  const profile = data ? ({ ...data, id: data.user_id } as Profile) : null;
+  return { user, profile };
+}
 
 export async function getDashboardData(): Promise<DashboardData> {
   const user = await getAuthenticatedUser();
@@ -64,11 +92,7 @@ export async function getDashboardData(): Promise<DashboardData> {
     // These reads are independent. Running them together removes a full
     // database round-trip from the dashboard critical path.
     const [profileResult, resumesResult, subscriptionResult] = await Promise.all([
-      supabase
-        .from('profiles')
-        .select('*')
-        .eq('user_id', user.id)
-        .single(),
+      getProfileForUser(user.id),
       supabase
         .from('resumes')
         .select('id, user_id, name, target_role, is_base_resume, job_id, created_at, updated_at')
@@ -77,10 +101,12 @@ export async function getDashboardData(): Promise<DashboardData> {
     ]);
 
     const { data, error: profileError } = profileResult;
-    let profile = data;
+    let profile: Profile | null = data
+      ? ({ ...data, id: data.user_id } as Profile)
+      : null;
 
     // If profile doesn't exist, create one
-    if (profileError?.code === 'PGRST116') {
+    if (!profile && !profileError) {
       const { data: newProfile, error: createError } = await supabase
         .from('profiles')
         .insert([{
@@ -106,7 +132,9 @@ export async function getDashboardData(): Promise<DashboardData> {
         throw new Error('Error creating user profile');
       }
 
-      profile = newProfile;
+      profile = newProfile
+        ? ({ ...newProfile, id: newProfile.user_id } as Profile)
+        : null;
     } else if (profileError) {
       console.error('Error fetching profile:', profileError);
       throw new Error('Error fetching dashboard data');
@@ -159,3 +187,58 @@ export async function getDashboardData(): Promise<DashboardData> {
   }
 }
 
+export interface ResumePageData {
+  resumes: ResumeSummary[];
+  totalCount: number;
+}
+
+const RESUME_SORT_COLUMNS = {
+  name: "name",
+  jobTitle: "target_role",
+  createdAt: "created_at",
+} as const;
+
+export async function getResumesPageData({
+  page,
+  pageSize,
+  sort,
+  direction,
+}: {
+  page: number;
+  pageSize: number;
+  sort: keyof typeof RESUME_SORT_COLUMNS;
+  direction: "asc" | "desc";
+}): Promise<ResumePageData> {
+  const user = await getAuthenticatedUser();
+  if (!user) {
+    throw new Error("User not authenticated");
+  }
+
+  const safePage = Math.max(1, page);
+  const safePageSize = Math.min(Math.max(1, pageSize), 100);
+  const from = (safePage - 1) * safePageSize;
+  const to = from + safePageSize - 1;
+  const supabase = await createClient();
+
+  const { data, count, error } = await supabase
+    .from("resumes")
+    .select('id, user_id, name, target_role, is_base_resume, job_id, created_at, updated_at', { count: "exact" })
+    .eq("user_id", user.id)
+    .order(RESUME_SORT_COLUMNS[sort], {
+      ascending: direction === "asc",
+      nullsFirst: false,
+    })
+    .range(from, to);
+
+  if (error) {
+    throw new Error("Error fetching resumes");
+  }
+
+  return {
+    resumes: (data ?? []).map((resume) => ({
+      ...resume,
+      target_role: resume.target_role || "",
+    })),
+    totalCount: count ?? 0,
+  };
+}

--- a/src/utils/actions/resumes/actions.ts
+++ b/src/utils/actions/resumes/actions.ts
@@ -1,6 +1,7 @@
 'use server'
 
 import { createClient } from "@/utils/supabase/server";
+import { getAuthenticatedUser } from "@/utils/actions";
 import { Profile, Resume, WorkExperience, Education, Skill, Project, Job } from "@/lib/types";
 import { revalidatePath } from 'next/cache';
 import { z } from 'zod';
@@ -96,9 +97,9 @@ async function runTrackedAIRequest<T extends { usage?: LanguageModelUsage }>(
 //  SUPABASE ACTIONS
 export async function getResumeById(resumeId: string): Promise<{ resume: Resume; profile: Profile; job: Job | null }> {
   const supabase = await createClient();
-  const { data: { user }, error } = await supabase.auth.getUser();
+  const user = await getAuthenticatedUser();
   
-  if (error || !user) {
+  if (!user) {
     throw new Error('User not authenticated');
   }
 

--- a/src/utils/actions/stripe/actions.ts
+++ b/src/utils/actions/stripe/actions.ts
@@ -1,9 +1,10 @@
 'use server';
 
 import { Stripe } from "stripe";
-import { createClient, createServiceClient } from '@/utils/supabase/server';
+import { createServiceClient } from '@/utils/supabase/server';
 import { Subscription } from '@/lib/types';
 import { getSubscriptionAccessState } from '@/lib/subscription-access';
+import { getAuthenticatedUser, getDashboardSubscription } from '@/utils/actions';
 import {
   mapStripeSubscriptionToAppSubscription,
   shouldSkipStaleInactiveSubscriptionUpdate,
@@ -305,57 +306,37 @@ export async function deleteCustomerAndData(uuid: string) {
 
 // Helper to get subscription status
 export async function getSubscriptionStatus() {
-  const supabase = await createClient();
+  const user = await getAuthenticatedUser();
 
-  const { data: { user }, error: userError } = await supabase.auth.getUser();
-  
-  if (userError || !user) {
+  if (!user) {
     throw new Error('User not authenticated');
   }
 
-  console.log(' looking for user ', user.id);
+  const { data: subscription, error: subscriptionError } =
+    await getDashboardSubscription(user.id);
 
-  const { data: subscription, error: subscriptionError } = await supabase
-    .from('subscriptions')
-    .select(`
-      subscription_plan,
-      subscription_status,
-      current_period_end,
-      trial_end,
-      stripe_customer_id,
-      stripe_subscription_id,
-      payment_failure_count,
-      last_payment_failed_at,
-      next_payment_attempt_at
-    `)
-    .eq('user_id', user.id)
-    .single();
-
-  if (subscriptionError) {
+  if (subscriptionError || !subscription) {
     // If no subscription found, return a default free plan instead of throwing
     void subscriptionError
-    if (subscriptionError.code === 'PGRST116') {
-      return {
-        subscription_plan: 'Free',
-        subscription_status: 'active',
-        current_period_end: null,
-        trial_end: null,
-        stripe_customer_id: null,
-        stripe_subscription_id: null,
-        payment_failure_count: 0,
-        last_payment_failed_at: null,
-        next_payment_attempt_at: null
-      };
-    }
-    throw new Error('Failed to fetch subscription status');
+    if (subscriptionError) throw new Error('Failed to fetch subscription status');
+    return {
+      subscription_plan: 'Free',
+      subscription_status: 'active',
+      current_period_end: null,
+      trial_end: null,
+      stripe_customer_id: null,
+      stripe_subscription_id: null,
+      payment_failure_count: 0,
+      last_payment_failed_at: null,
+      next_payment_attempt_at: null
+    };
   }
 
   return subscription;
 }
 
 export async function checkSubscriptionPlan() {
-  const supabase = await createClient();
-  const { data: { user } } = await supabase.auth.getUser();
+  const user = await getAuthenticatedUser();
   
   if (!user) {
     return {
@@ -368,27 +349,11 @@ export async function checkSubscriptionPlan() {
     };
   }
 
-  const { data } = await supabase
-    .from('subscriptions')
-    .select('subscription_plan, subscription_status, stripe_subscription_id, current_period_end, trial_end')
-    .eq('user_id', user.id)
-    .maybeSingle();
+  const { data } = await getDashboardSubscription(user.id);
 
   const subscriptionState = getSubscriptionAccessState(data);
   const effectivePlan = data ? subscriptionState.effectivePlan : '';
 
-  console.log('🧮 checkSubscriptionPlan', {
-    userId: user.id,
-    subscription_plan: data?.subscription_plan,
-    subscription_status: data?.subscription_status,
-    stripe_subscription_id: data?.stripe_subscription_id,
-    current_period_end: data?.current_period_end,
-    trial_end: data?.trial_end,
-    isTrialing: subscriptionState.isTrialing,
-    hasProAccess: subscriptionState.hasProAccess,
-    effectivePlan,
-  });
-  
   return {
     plan: effectivePlan,
     status: data?.subscription_status || '',
@@ -420,19 +385,14 @@ export async function hasActiveSubscriptionOrTrial(userId: string): Promise<bool
 export async function getSubscriptionPlan(returnId: true): Promise<{ plan: string; id: string }>;
 export async function getSubscriptionPlan(returnId?: boolean): Promise<string | { plan: string; id: string }>;
 export async function getSubscriptionPlan(returnId?: boolean) {
-  const supabase = await createClient();
-  const { data: { user } } = await supabase.auth.getUser();
+  const user = await getAuthenticatedUser();
   
   if (!user) {
     if (returnId) return { plan: '', id: '' };
     return '';
   }
 
-  const { data } = await supabase
-    .from('subscriptions')
-    .select('subscription_plan, subscription_status, stripe_subscription_id, current_period_end, trial_end')
-    .eq('user_id', user.id)
-    .maybeSingle();
+  const { data } = await getDashboardSubscription(user.id);
 
   const subscriptionState = getSubscriptionAccessState(data);
   const effectivePlan = data ? subscriptionState.effectivePlan : '';

--- a/src/utils/auth.ts
+++ b/src/utils/auth.ts
@@ -1,41 +1,11 @@
-import { headers } from 'next/headers';
-import { createClient } from './supabase/server';
-import AuthCache from './auth-cache';
+import { getAuthenticatedUser as getRequestAuthenticatedUser } from './actions';
 
 // Cache the auth check using React cache()
 export async function getAuthenticatedUser() {
-  const headersList = await headers();
-  const requestId = headersList.get('x-request-id');
-  const userId = headersList.get('x-user-id');
-  
-  // If we have a request ID and user ID in headers, check cache first
-  if (requestId && userId) {
-    const cachedUser = AuthCache.get(requestId);
-    if (cachedUser) {
-      return {
-        id: cachedUser.id,
-        email: cachedUser.email
-      };
-    }
-  }
-
-  // If not in cache, get from Supabase
-  const supabase = await createClient();
-  const { data: { user }, error } = await supabase.auth.getUser();
-
-  if (error || !user) {
+  const user = await getRequestAuthenticatedUser();
+  if (!user) {
     throw new Error('User not authenticated');
   }
-
-  // If we have a request ID, cache the result
-  if (requestId) {
-    AuthCache.set(requestId, {
-      id: user.id,
-      email: user.email || null,
-      timestamp: Date.now()
-    });
-  }
-
   return user;
 }
 
@@ -43,4 +13,4 @@ export async function getAuthenticatedUser() {
 export const getUserId = async () => {
   const user = await getAuthenticatedUser();
   return user.id;
-}; 
+};

--- a/supabase/migrations/20260811180516_optimize_authenticated_data_access.sql
+++ b/supabase/migrations/20260811180516_optimize_authenticated_data_access.sql
@@ -1,0 +1,115 @@
+-- Speed up the authenticated list and ownership queries used by the
+-- dashboard, jobs page, and resume editor.
+CREATE INDEX IF NOT EXISTS jobs_user_id_active_created_at_idx
+  ON public.jobs (user_id, is_active, created_at DESC);
+
+CREATE INDEX IF NOT EXISTS resumes_user_id_created_at_idx
+  ON public.resumes (user_id, created_at DESC);
+
+CREATE INDEX IF NOT EXISTS resumes_job_id_idx
+  ON public.resumes (job_id);
+
+-- These tables contain user-owned data. The old policies were scoped to the
+-- public role, duplicated in places, and evaluated auth.uid() per row.
+ALTER TABLE public.profiles ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.jobs ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.resumes ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.subscriptions ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS "Users can insert own profile" ON public.profiles;
+DROP POLICY IF EXISTS "Users can read own profile" ON public.profiles;
+DROP POLICY IF EXISTS "Users can update own profile" ON public.profiles;
+DROP POLICY IF EXISTS "Users can view own profile" ON public.profiles;
+DROP POLICY IF EXISTS profiles_policy ON public.profiles;
+
+CREATE POLICY profiles_select_own
+  ON public.profiles FOR SELECT
+  TO authenticated
+  USING ((SELECT auth.uid()) = user_id);
+
+CREATE POLICY profiles_insert_own
+  ON public.profiles FOR INSERT
+  TO authenticated
+  WITH CHECK ((SELECT auth.uid()) = user_id);
+
+CREATE POLICY profiles_update_own
+  ON public.profiles FOR UPDATE
+  TO authenticated
+  USING ((SELECT auth.uid()) = user_id)
+  WITH CHECK ((SELECT auth.uid()) = user_id);
+
+DROP POLICY IF EXISTS "Allow users to view jobs" ON public.jobs;
+DROP POLICY IF EXISTS "Users can delete their own jobs" ON public.jobs;
+DROP POLICY IF EXISTS "Users can insert their own jobs" ON public.jobs;
+DROP POLICY IF EXISTS "Users can update their own jobs" ON public.jobs;
+DROP POLICY IF EXISTS jobs_policy ON public.jobs;
+
+CREATE POLICY jobs_select_own
+  ON public.jobs FOR SELECT
+  TO authenticated
+  USING ((SELECT auth.uid()) = user_id);
+
+CREATE POLICY jobs_insert_own
+  ON public.jobs FOR INSERT
+  TO authenticated
+  WITH CHECK ((SELECT auth.uid()) = user_id);
+
+CREATE POLICY jobs_update_own
+  ON public.jobs FOR UPDATE
+  TO authenticated
+  USING ((SELECT auth.uid()) = user_id)
+  WITH CHECK ((SELECT auth.uid()) = user_id);
+
+CREATE POLICY jobs_delete_own
+  ON public.jobs FOR DELETE
+  TO authenticated
+  USING ((SELECT auth.uid()) = user_id);
+
+DROP POLICY IF EXISTS "Users can delete own resumes" ON public.resumes;
+DROP POLICY IF EXISTS "Users can insert own resumes" ON public.resumes;
+DROP POLICY IF EXISTS "Users can read own resumes" ON public.resumes;
+DROP POLICY IF EXISTS "Users can update own resumes" ON public.resumes;
+DROP POLICY IF EXISTS resumes_policy ON public.resumes;
+
+CREATE POLICY resumes_select_own
+  ON public.resumes FOR SELECT
+  TO authenticated
+  USING ((SELECT auth.uid()) = user_id);
+
+CREATE POLICY resumes_insert_own
+  ON public.resumes FOR INSERT
+  TO authenticated
+  WITH CHECK ((SELECT auth.uid()) = user_id);
+
+CREATE POLICY resumes_update_own
+  ON public.resumes FOR UPDATE
+  TO authenticated
+  USING ((SELECT auth.uid()) = user_id)
+  WITH CHECK ((SELECT auth.uid()) = user_id);
+
+CREATE POLICY resumes_delete_own
+  ON public.resumes FOR DELETE
+  TO authenticated
+  USING ((SELECT auth.uid()) = user_id);
+
+DROP POLICY IF EXISTS "Service role can manage subscriptions" ON public.subscriptions;
+DROP POLICY IF EXISTS "Users can view own subscription" ON public.subscriptions;
+DROP POLICY IF EXISTS subscriptions_policy ON public.subscriptions;
+
+CREATE POLICY subscriptions_service_role_manage
+  ON public.subscriptions FOR ALL
+  TO service_role
+  USING (true)
+  WITH CHECK (true);
+
+CREATE POLICY subscriptions_select_own
+  ON public.subscriptions FOR SELECT
+  TO authenticated
+  USING ((SELECT auth.uid()) = user_id);
+
+-- No anonymous client needs access to these private tables. RLS is the row
+-- boundary; revoking the table grant makes the boundary explicit as well.
+REVOKE ALL ON TABLE public.profiles, public.jobs, public.resumes, public.subscriptions FROM anon;
+GRANT SELECT, INSERT, UPDATE, DELETE ON TABLE public.profiles, public.jobs, public.resumes TO authenticated;
+GRANT SELECT ON TABLE public.subscriptions TO authenticated;
+GRANT ALL ON TABLE public.subscriptions TO service_role;


### PR DESCRIPTION
## What changed

- Prevent unnecessary prefetching of private dashboard routes.
- Share request-scoped auth and subscription reads across dashboard, settings, profile, subscription, and editor loaders.
- Move resume-list sorting and pagination into Supabase.
- Add authenticated ownership indexes and tighten profiles, jobs, resumes, and subscriptions RLS policies.
- Remove the editor's full-resume JSON serialization on every change and defer heavy preview updates.
- Add regression coverage for editor dirty-state behavior.

## Root cause

The dashboard was silently prefetched into multiple private routes, and several pages bypassed the existing request memoization. Resume list queries also sorted and paginated in JavaScript while the database lacked the relevant ownership indexes.

## Validation

- `pnpm test` — 93 passing
- `pnpm lint`
- `pnpm typecheck`
- `pnpm check:trust`
- `pnpm build`
- Production Supabase migration applied and verified with indexes, RLS policy inspection, and EXPLAIN plans
- Local app boot and unauthenticated route smoke test completed

The pre-existing local demo fixture files were intentionally left out of this PR.