### PR TITLE
Fix production profile projection

### DIFF
--- a/src/utils/actions.ts
+++ b/src/utils/actions.ts
@@ -58,7 +58,7 @@ export const getProfileForUser = cache(async (userId: string) => {
   const supabase = await createClient();
   return supabase
     .from('profiles')
-    .select('user_id, first_name, last_name, email, phone_number, location, website, linkedin_url, github_url, is_admin, work_experience, education, skills, projects, certifications, created_at, updated_at')
+    .select('user_id, first_name, last_name, email, phone_number, location, website, linkedin_url, github_url, work_experience, education, skills, projects, certifications, created_at, updated_at')
     .eq('user_id', userId)
     .maybeSingle();
 });


### PR DESCRIPTION
Fixes the authenticated dashboard regression found after deploying PR #80. The shared profile projection requested `profiles.is_admin`, but that column is not present in the production schema, causing `/home` and `/profile` to redirect to the landing page. Removes that field from the shared projection while preserving the optional type for existing admin-specific code.

Verification: `pnpm test`, `pnpm lint`, and `pnpm typecheck` pass.