### PR TITLE
Add billing reconciliation and payment alerts

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -46,6 +46,9 @@ REDIS_URL=redis://localhost:6379
 # STRIPE_WEBHOOK_SECRET=whsec_...
 # NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY=pk_test_...
 # NEXT_PUBLIC_STRIPE_PRO_PRICE_ID=price_...
+CRON_SECRET=your_vercel_cron_secret
+# Optional Slack/Discord-compatible webhook for deduplicated billing alerts.
+BILLING_ALERT_WEBHOOK_URL=
 
 # ===========================================
 # POSTHOG (Optional - Product Analytics)

--- a/docker/supabase/volumes/db/init/01-app-schema.sql
+++ b/docker/supabase/volumes/db/init/01-app-schema.sql
@@ -52,6 +52,19 @@ CREATE TRIGGER update_subscriptions_updated_at BEFORE
 UPDATE ON subscriptions FOR EACH ROW
 EXECUTE FUNCTION update_updated_at_column();
 
+ALTER TABLE public.subscriptions
+  ADD COLUMN IF NOT EXISTS payment_failure_count integer NOT NULL DEFAULT 0,
+  ADD COLUMN IF NOT EXISTS last_payment_failed_at timestamp with time zone,
+  ADD COLUMN IF NOT EXISTS next_payment_attempt_at timestamp with time zone;
+
+ALTER TABLE public.subscriptions
+  DROP CONSTRAINT IF EXISTS subscriptions_subscription_status_check;
+ALTER TABLE public.subscriptions
+  ADD CONSTRAINT subscriptions_subscription_status_check CHECK (
+    (subscription_status IS NULL) OR
+    (subscription_status = ANY (ARRAY['active'::text, 'past_due'::text, 'canceled'::text]))
+  );
+
 -- Stripe webhook idempotency table
 CREATE TABLE IF NOT EXISTS public.stripe_webhook_events (
   event_id text NOT NULL,
@@ -70,6 +83,45 @@ EXECUTE FUNCTION update_updated_at_column();
 ALTER TABLE public.stripe_webhook_events ENABLE ROW LEVEL SECURITY;
 REVOKE ALL ON TABLE public.stripe_webhook_events FROM anon, authenticated;
 GRANT ALL ON TABLE public.stripe_webhook_events TO service_role;
+
+ALTER TABLE public.stripe_webhook_events
+  ADD COLUMN IF NOT EXISTS status text NOT NULL DEFAULT 'processing',
+  ADD COLUMN IF NOT EXISTS attempt_count integer NOT NULL DEFAULT 1,
+  ADD COLUMN IF NOT EXISTS last_attempt_at timestamp with time zone,
+  ADD COLUMN IF NOT EXISTS last_error text,
+  ADD COLUMN IF NOT EXISTS event_created_at timestamp with time zone;
+
+UPDATE public.stripe_webhook_events
+SET status = CASE WHEN processed_at IS NULL THEN 'failed' ELSE 'processed' END,
+    last_attempt_at = COALESCE(last_attempt_at, updated_at),
+    event_created_at = COALESCE(event_created_at, created_at)
+WHERE status = 'processing';
+
+CREATE TABLE IF NOT EXISTS public.billing_alerts (
+  alert_key text NOT NULL PRIMARY KEY,
+  alert_type text NOT NULL,
+  severity text NOT NULL,
+  stripe_subscription_id text NULL,
+  stripe_customer_id text NULL,
+  details jsonb NOT NULL DEFAULT '{}'::jsonb,
+  occurrence_count integer NOT NULL DEFAULT 1,
+  first_seen_at timestamp with time zone NOT NULL DEFAULT timezone('utc'::text, now()),
+  last_seen_at timestamp with time zone NOT NULL DEFAULT timezone('utc'::text, now()),
+  last_notified_at timestamp with time zone NULL,
+  resolved_at timestamp with time zone NULL,
+  updated_at timestamp with time zone NOT NULL DEFAULT timezone('utc'::text, now()),
+  CONSTRAINT billing_alerts_type_check CHECK (alert_type = ANY (ARRAY['payment_failed'::text, 'billing_state_mismatch'::text, 'mapping_missing'::text, 'webhook_processing_failed'::text])),
+  CONSTRAINT billing_alerts_severity_check CHECK (severity = ANY (ARRAY['warning'::text, 'critical'::text])),
+  CONSTRAINT billing_alerts_occurrence_count_positive CHECK (occurrence_count > 0)
+);
+
+DROP TRIGGER IF EXISTS update_billing_alerts_updated_at ON public.billing_alerts;
+CREATE TRIGGER update_billing_alerts_updated_at BEFORE UPDATE ON public.billing_alerts
+FOR EACH ROW EXECUTE FUNCTION update_updated_at_column();
+CREATE INDEX IF NOT EXISTS billing_alerts_open_idx ON public.billing_alerts (resolved_at, severity, last_seen_at);
+ALTER TABLE public.billing_alerts ENABLE ROW LEVEL SECURITY;
+REVOKE ALL ON TABLE public.billing_alerts FROM anon, authenticated;
+GRANT ALL ON TABLE public.billing_alerts TO service_role;
 
 -- Jobs table
 CREATE TABLE IF NOT EXISTS public.jobs (

--- a/helm/resumelm/templates/db-init-configmap.yaml
+++ b/helm/resumelm/templates/db-init-configmap.yaml
@@ -157,6 +157,19 @@ data:
     CREATE TRIGGER update_subscriptions_updated_at BEFORE UPDATE ON subscriptions
     FOR EACH ROW EXECUTE FUNCTION update_updated_at_column();
 
+    ALTER TABLE public.subscriptions
+      ADD COLUMN IF NOT EXISTS payment_failure_count integer NOT NULL DEFAULT 0,
+      ADD COLUMN IF NOT EXISTS last_payment_failed_at timestamp with time zone,
+      ADD COLUMN IF NOT EXISTS next_payment_attempt_at timestamp with time zone;
+
+    ALTER TABLE public.subscriptions
+      DROP CONSTRAINT IF EXISTS subscriptions_subscription_status_check;
+    ALTER TABLE public.subscriptions
+      ADD CONSTRAINT subscriptions_subscription_status_check CHECK (
+        (subscription_status IS NULL) OR
+        (subscription_status = ANY (ARRAY['active'::text, 'past_due'::text, 'canceled'::text]))
+      );
+
     -- Stripe webhook idempotency table
     CREATE TABLE IF NOT EXISTS public.stripe_webhook_events (
       event_id text NOT NULL,
@@ -174,6 +187,45 @@ data:
     ALTER TABLE public.stripe_webhook_events ENABLE ROW LEVEL SECURITY;
     REVOKE ALL ON TABLE public.stripe_webhook_events FROM anon, authenticated;
     GRANT ALL ON TABLE public.stripe_webhook_events TO service_role;
+
+    ALTER TABLE public.stripe_webhook_events
+      ADD COLUMN IF NOT EXISTS status text NOT NULL DEFAULT 'processing',
+      ADD COLUMN IF NOT EXISTS attempt_count integer NOT NULL DEFAULT 1,
+      ADD COLUMN IF NOT EXISTS last_attempt_at timestamp with time zone,
+      ADD COLUMN IF NOT EXISTS last_error text,
+      ADD COLUMN IF NOT EXISTS event_created_at timestamp with time zone;
+
+    UPDATE public.stripe_webhook_events
+    SET status = CASE WHEN processed_at IS NULL THEN 'failed' ELSE 'processed' END,
+        last_attempt_at = COALESCE(last_attempt_at, updated_at),
+        event_created_at = COALESCE(event_created_at, created_at)
+    WHERE status = 'processing';
+
+    CREATE TABLE IF NOT EXISTS public.billing_alerts (
+      alert_key text NOT NULL PRIMARY KEY,
+      alert_type text NOT NULL,
+      severity text NOT NULL,
+      stripe_subscription_id text NULL,
+      stripe_customer_id text NULL,
+      details jsonb NOT NULL DEFAULT '{}'::jsonb,
+      occurrence_count integer NOT NULL DEFAULT 1,
+      first_seen_at timestamp with time zone NOT NULL DEFAULT timezone('utc'::text, now()),
+      last_seen_at timestamp with time zone NOT NULL DEFAULT timezone('utc'::text, now()),
+      last_notified_at timestamp with time zone NULL,
+      resolved_at timestamp with time zone NULL,
+      updated_at timestamp with time zone NOT NULL DEFAULT timezone('utc'::text, now()),
+      CONSTRAINT billing_alerts_type_check CHECK (alert_type = ANY (ARRAY['payment_failed'::text, 'billing_state_mismatch'::text, 'mapping_missing'::text, 'webhook_processing_failed'::text])),
+      CONSTRAINT billing_alerts_severity_check CHECK (severity = ANY (ARRAY['warning'::text, 'critical'::text])),
+      CONSTRAINT billing_alerts_occurrence_count_positive CHECK (occurrence_count > 0)
+    );
+
+    DROP TRIGGER IF EXISTS update_billing_alerts_updated_at ON public.billing_alerts;
+    CREATE TRIGGER update_billing_alerts_updated_at BEFORE UPDATE ON public.billing_alerts
+    FOR EACH ROW EXECUTE FUNCTION update_updated_at_column();
+    CREATE INDEX IF NOT EXISTS billing_alerts_open_idx ON public.billing_alerts (resolved_at, severity, last_seen_at);
+    ALTER TABLE public.billing_alerts ENABLE ROW LEVEL SECURITY;
+    REVOKE ALL ON TABLE public.billing_alerts FROM anon, authenticated;
+    GRANT ALL ON TABLE public.billing_alerts TO service_role;
 
     -- Jobs table
     CREATE TABLE IF NOT EXISTS public.jobs (

--- a/schema.sql
+++ b/schema.sql
@@ -53,6 +53,11 @@ CREATE TRIGGER update_subscriptions_updated_at BEFORE
 UPDATE ON subscriptions FOR EACH ROW
 EXECUTE FUNCTION update_updated_at_column();
 
+ALTER TABLE public.subscriptions
+  ADD COLUMN IF NOT EXISTS payment_failure_count integer NOT NULL DEFAULT 0,
+  ADD COLUMN IF NOT EXISTS last_payment_failed_at timestamp with time zone,
+  ADD COLUMN IF NOT EXISTS next_payment_attempt_at timestamp with time zone;
+
 -- Stripe webhook idempotency table
 CREATE TABLE IF NOT EXISTS public.stripe_webhook_events (
   event_id text NOT NULL,
@@ -71,6 +76,45 @@ EXECUTE FUNCTION update_updated_at_column();
 ALTER TABLE public.stripe_webhook_events ENABLE ROW LEVEL SECURITY;
 REVOKE ALL ON TABLE public.stripe_webhook_events FROM anon, authenticated;
 GRANT ALL ON TABLE public.stripe_webhook_events TO service_role;
+
+ALTER TABLE public.stripe_webhook_events
+  ADD COLUMN IF NOT EXISTS status text NOT NULL DEFAULT 'processing',
+  ADD COLUMN IF NOT EXISTS attempt_count integer NOT NULL DEFAULT 1,
+  ADD COLUMN IF NOT EXISTS last_attempt_at timestamp with time zone,
+  ADD COLUMN IF NOT EXISTS last_error text,
+  ADD COLUMN IF NOT EXISTS event_created_at timestamp with time zone;
+
+UPDATE public.stripe_webhook_events
+SET status = CASE WHEN processed_at IS NULL THEN 'failed' ELSE 'processed' END,
+    last_attempt_at = COALESCE(last_attempt_at, updated_at),
+    event_created_at = COALESCE(event_created_at, created_at)
+WHERE status = 'processing';
+
+CREATE TABLE IF NOT EXISTS public.billing_alerts (
+  alert_key text NOT NULL PRIMARY KEY,
+  alert_type text NOT NULL,
+  severity text NOT NULL,
+  stripe_subscription_id text NULL,
+  stripe_customer_id text NULL,
+  details jsonb NOT NULL DEFAULT '{}'::jsonb,
+  occurrence_count integer NOT NULL DEFAULT 1,
+  first_seen_at timestamp with time zone NOT NULL DEFAULT timezone('utc'::text, now()),
+  last_seen_at timestamp with time zone NOT NULL DEFAULT timezone('utc'::text, now()),
+  last_notified_at timestamp with time zone NULL,
+  resolved_at timestamp with time zone NULL,
+  updated_at timestamp with time zone NOT NULL DEFAULT timezone('utc'::text, now()),
+  CONSTRAINT billing_alerts_type_check CHECK (alert_type = ANY (ARRAY['payment_failed'::text, 'billing_state_mismatch'::text, 'mapping_missing'::text, 'webhook_processing_failed'::text])),
+  CONSTRAINT billing_alerts_severity_check CHECK (severity = ANY (ARRAY['warning'::text, 'critical'::text])),
+  CONSTRAINT billing_alerts_occurrence_count_positive CHECK (occurrence_count > 0)
+);
+
+DROP TRIGGER IF EXISTS update_billing_alerts_updated_at ON public.billing_alerts;
+CREATE TRIGGER update_billing_alerts_updated_at BEFORE UPDATE ON public.billing_alerts
+FOR EACH ROW EXECUTE FUNCTION update_updated_at_column();
+CREATE INDEX IF NOT EXISTS billing_alerts_open_idx ON public.billing_alerts (resolved_at, severity, last_seen_at);
+ALTER TABLE public.billing_alerts ENABLE ROW LEVEL SECURITY;
+REVOKE ALL ON TABLE public.billing_alerts FROM anon, authenticated;
+GRANT ALL ON TABLE public.billing_alerts TO service_role;
 
 -- Jobs table
 CREATE TABLE IF NOT EXISTS public.jobs (

--- a/src/app/api/cron/billing-reconciliation/route.ts
+++ b/src/app/api/cron/billing-reconciliation/route.ts
@@ -1,0 +1,187 @@
+import Stripe from "stripe";
+
+import { reportBillingAlert } from "@/lib/billing/alerts";
+import {
+  compareStripeAndSupabaseState,
+  type StoredReconciliationSnapshot,
+  type StripeReconciliationSnapshot,
+} from "@/lib/billing/reconciliation";
+import { createServiceClient } from "@/utils/supabase/server";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+let stripe: Stripe | null = null;
+
+function getStripe(): Stripe {
+  if (!stripe) {
+    if (!process.env.STRIPE_SECRET_KEY) {
+      throw new Error("STRIPE_SECRET_KEY is not configured");
+    }
+    stripe = new Stripe(process.env.STRIPE_SECRET_KEY, {
+      apiVersion: "2025-04-30.basil",
+    });
+  }
+  return stripe;
+}
+
+function isAuthorized(request: Request): boolean {
+  const secret = process.env.CRON_SECRET;
+  if (!secret) return false;
+  return request.headers.get("authorization") === `Bearer ${secret}`;
+}
+
+async function listAllStripeSubscriptions(): Promise<Stripe.Subscription[]> {
+  const subscriptions: Stripe.Subscription[] = [];
+  let startingAfter: string | undefined;
+
+  do {
+    const page = await getStripe().subscriptions.list({
+      status: "all",
+      limit: 100,
+      ...(startingAfter ? { starting_after: startingAfter } : {}),
+    });
+    subscriptions.push(...page.data);
+    startingAfter = page.has_more ? page.data.at(-1)?.id : undefined;
+  } while (startingAfter);
+
+  return subscriptions;
+}
+
+function toStripeSnapshot(subscription: Stripe.Subscription): StripeReconciliationSnapshot | null {
+  const item = subscription.items.data[0];
+  if (!item) return null;
+
+  return {
+    id: subscription.id,
+    priceId: item.price.id,
+    status: subscription.status,
+    currentPeriodEnd: item.current_period_end
+      ? new Date(item.current_period_end * 1000).toISOString()
+      : null,
+    trialEnd: subscription.trial_end
+      ? new Date(subscription.trial_end * 1000).toISOString()
+      : null,
+    cancelAtPeriodEnd: subscription.cancel_at_period_end,
+  };
+}
+
+async function runBillingReconciliation() {
+  const proPriceId = process.env.NEXT_PUBLIC_STRIPE_PRO_PRICE_ID;
+  if (!proPriceId) throw new Error("NEXT_PUBLIC_STRIPE_PRO_PRICE_ID is not configured");
+
+  const supabase = await createServiceClient();
+  const [{ data: storedRows, error: storedError }, stripeSubscriptions] = await Promise.all([
+    supabase
+      .from("subscriptions")
+      .select(
+        "user_id, stripe_subscription_id, subscription_plan, subscription_status, current_period_end, trial_end, payment_failure_count",
+      )
+      .not("stripe_subscription_id", "is", null),
+    listAllStripeSubscriptions(),
+  ]);
+
+  if (storedError) throw storedError;
+
+  const storedByStripeId = new Map(
+    ((storedRows ?? []) as StoredReconciliationSnapshot[])
+      .filter((row) => row.stripe_subscription_id)
+      .map((row) => [row.stripe_subscription_id as string, row]),
+  );
+
+  let checked = 0;
+  let mismatches = 0;
+  let mappingMissing = 0;
+  let staleEntitlements = 0;
+  const seenStripeIds = new Set<string>();
+
+  for (const subscription of stripeSubscriptions) {
+    const snapshot = toStripeSnapshot(subscription);
+    if (!snapshot) continue;
+    checked += 1;
+    seenStripeIds.add(snapshot.id);
+
+    const mismatch = compareStripeAndSupabaseState({
+      stripe: snapshot,
+      stored: storedByStripeId.get(snapshot.id) ?? null,
+      proPriceId,
+    });
+    if (!mismatch) continue;
+
+    mismatches += 1;
+    if (mismatch.kind === "mapping_missing") mappingMissing += 1;
+    if (mismatch.kind === "stale_entitlement") staleEntitlements += 1;
+
+    await reportBillingAlert(supabase, {
+      type: mismatch.kind === "mapping_missing" ? "mapping_missing" : "billing_state_mismatch",
+      severity: mismatch.severity,
+      alertKey: `reconciliation:${snapshot.id}:${mismatch.kind}:${mismatch.expectedState}:${mismatch.actualState ?? "missing"}`,
+      message: `Stripe and Supabase disagree for subscription ${snapshot.id.slice(-8)} (${mismatch.kind}).`,
+      stripeSubscriptionId: snapshot.id,
+      details: {
+        expected_state: mismatch.expectedState,
+        actual_state: mismatch.actualState,
+        expected_plan: mismatch.expectedPlan,
+        expected_status: mismatch.expectedStatus,
+        stripe_status: snapshot.status,
+      },
+    });
+  }
+
+  for (const stored of storedByStripeId.values()) {
+    if (!stored.stripe_subscription_id || seenStripeIds.has(stored.stripe_subscription_id)) continue;
+
+    const mismatch = compareStripeAndSupabaseState({
+      stripe: {
+        id: stored.stripe_subscription_id,
+        priceId: "missing",
+        status: "canceled",
+        currentPeriodEnd: null,
+        trialEnd: null,
+        cancelAtPeriodEnd: false,
+      },
+      stored,
+      proPriceId,
+    });
+
+    if (mismatch?.kind !== "stale_entitlement") continue;
+    staleEntitlements += 1;
+    mismatches += 1;
+    await reportBillingAlert(supabase, {
+      type: "billing_state_mismatch",
+      severity: "critical",
+      alertKey: `reconciliation:missing:${stored.stripe_subscription_id}`,
+      message: `Supabase still grants Pro for a subscription missing in Stripe (${stored.stripe_subscription_id.slice(-8)}).`,
+      stripeSubscriptionId: stored.stripe_subscription_id,
+      details: {
+        expected_state: "free",
+        actual_state: mismatch.actualState,
+        stored_plan: stored.subscription_plan,
+        stored_status: stored.subscription_status,
+      },
+    });
+  }
+
+  return {
+    checkedStripeSubscriptions: checked,
+    linkedSupabaseSubscriptions: storedByStripeId.size,
+    mismatches,
+    mappingMissing,
+    staleEntitlements,
+  };
+}
+
+export async function GET(request: Request) {
+  if (!isAuthorized(request)) {
+    return Response.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  try {
+    return Response.json({ ok: true, ...(await runBillingReconciliation()) });
+  } catch (error) {
+    console.error("Billing reconciliation failed", {
+      error: error instanceof Error ? error.message : "Unknown error",
+    });
+    return Response.json({ error: "Billing reconciliation failed" }, { status: 500 });
+  }
+}

--- a/src/app/api/webhooks/stripe/route.ts
+++ b/src/app/api/webhooks/stripe/route.ts
@@ -4,6 +4,7 @@ import { headers } from 'next/headers'
 import Stripe from 'stripe'
 import { manageSubscriptionStatusChange } from '@/utils/actions/stripe/actions'
 import { createServiceClient } from '@/utils/supabase/server'
+import { reportBillingAlert } from '@/lib/billing/alerts'
 import { AnalyticsEvents } from '@/lib/analytics/events'
 import { captureServerAnalyticsEvent } from '@/lib/analytics/server'
 import {
@@ -87,15 +88,17 @@ async function reserveWebhookEvent(
   supabase: ServiceSupabaseClient,
   event: Stripe.Event
 ): Promise<'process' | 'skip'> {
+  const now = new Date();
+  const staleProcessingCutoff = now.getTime() - 5 * 60 * 1000;
   const { data: existingEvent, error: existingEventError } = await supabase
     .from('stripe_webhook_events')
-    .select('event_id, processed_at')
+    .select('event_id, processed_at, status, attempt_count, last_attempt_at')
     .eq('event_id', event.id)
     .maybeSingle();
 
   if (existingEventError) throw existingEventError;
 
-  if (existingEvent?.processed_at) {
+  if (existingEvent?.processed_at || existingEvent?.status === 'processed') {
     return 'skip';
   }
 
@@ -105,6 +108,10 @@ async function reserveWebhookEvent(
       .insert({
         event_id: event.id,
         event_type: event.type,
+        status: 'processing',
+        attempt_count: 1,
+        last_attempt_at: now.toISOString(),
+        event_created_at: new Date(event.created * 1000).toISOString(),
       });
 
     if (insertError) {
@@ -113,15 +120,52 @@ async function reserveWebhookEvent(
 
       const { data: duplicateEvent, error: duplicateEventError } = await supabase
         .from('stripe_webhook_events')
-        .select('event_id, processed_at')
+        .select('event_id, processed_at, status, attempt_count, last_attempt_at')
         .eq('event_id', event.id)
         .maybeSingle();
 
       if (duplicateEventError) throw duplicateEventError;
-      if (duplicateEvent?.processed_at) {
+      if (duplicateEvent?.processed_at || duplicateEvent?.status === 'processed') {
         return 'skip';
       }
+      if (
+        duplicateEvent?.status === 'processing' &&
+        duplicateEvent.last_attempt_at &&
+        Date.parse(duplicateEvent.last_attempt_at) > staleProcessingCutoff
+      ) {
+        return 'skip';
+      }
+      if (duplicateEvent) {
+        const { error: claimError } = await supabase
+          .from('stripe_webhook_events')
+          .update({
+            status: 'processing',
+            attempt_count: (duplicateEvent.attempt_count ?? 1) + 1,
+            last_attempt_at: now.toISOString(),
+            last_error: null,
+          })
+          .eq('event_id', event.id);
+        if (claimError) throw claimError;
+      }
     }
+  } else {
+    if (
+      existingEvent.status === 'processing' &&
+      existingEvent.last_attempt_at &&
+      Date.parse(existingEvent.last_attempt_at) > staleProcessingCutoff
+    ) {
+      return 'skip';
+    }
+    const { error: claimError } = await supabase
+      .from('stripe_webhook_events')
+      .update({
+        status: 'processing',
+        attempt_count: (existingEvent.attempt_count ?? 1) + 1,
+        last_attempt_at: now.toISOString(),
+        last_error: null,
+      })
+      .eq('event_id', event.id);
+    if (claimError) throw claimError;
   }
 
   return 'process';
@@ -133,13 +177,40 @@ async function markWebhookEventProcessed(
 ): Promise<void> {
   const { error } = await supabase
     .from('stripe_webhook_events')
-    .update({ processed_at: new Date().toISOString() })
+    .update({
+      status: 'processed',
+      processed_at: new Date().toISOString(),
+      last_error: null,
+    })
     .eq('event_id', eventId);
 
   if (error) throw error;
 }
 
+async function markWebhookEventFailed(
+  supabase: ServiceSupabaseClient,
+  eventId: string,
+  error: Error,
+): Promise<void> {
+  const { error: updateError } = await supabase
+    .from('stripe_webhook_events')
+    .update({
+      status: 'failed',
+      last_attempt_at: new Date().toISOString(),
+      last_error: error.message.slice(0, 2000),
+    })
+    .eq('event_id', eventId);
+
+  if (updateError) {
+    console.error('Unable to persist Stripe webhook failure state', {
+      eventId,
+      error: updateError,
+    });
+  }
+}
+
 async function handleSubscriptionChange(
+  supabase: ServiceSupabaseClient,
   stripeCustomerId: string,
   subscriptionId: string
 ): Promise<Partial<Subscription>> {
@@ -157,6 +228,22 @@ async function handleSubscriptionChange(
       subscriptionId,
       stripeCustomerId
     );
+
+    if (!subscriptionData.user_id) {
+      await reportBillingAlert(supabase, {
+        type: 'mapping_missing',
+        severity: 'critical',
+        alertKey: `mapping-missing:${subscriptionId}`,
+        message: `Stripe subscription ${subscriptionId.slice(-8)} has no Supabase user mapping.`,
+        stripeSubscriptionId: subscriptionId,
+        stripeCustomerId,
+        details: {
+          stripe_subscription_id: subscriptionId,
+          stripe_customer_id: stripeCustomerId,
+          subscription_status: subscriptionData.subscription_status ?? null,
+        },
+      });
+    }
     
     console.log('✨ Final Subscription State:', {
       result: 'success',
@@ -302,6 +389,22 @@ async function captureInvoicePaymentFailedEvent(input: {
     throw recoveryUpdateError;
   }
 
+  await reportBillingAlert(input.supabase, {
+    type: 'payment_failed',
+    severity: 'warning',
+    alertKey: `payment-failed:${input.invoice.id}`,
+    message: `A Stripe invoice payment failed for subscription ${input.subscriptionData.stripe_subscription_id?.slice(-8) ?? 'unknown'}.`,
+    stripeSubscriptionId: input.subscriptionData.stripe_subscription_id,
+    details: {
+      stripe_invoice_id: input.invoice.id,
+      amount_due: input.invoice.amount_due,
+      amount_remaining: input.invoice.amount_remaining,
+      currency: input.invoice.currency,
+      attempt_count: input.invoice.attempt_count,
+      next_payment_attempt: recoveryFields.next_payment_attempt_at,
+    },
+  });
+
   await captureServerAnalyticsEvent({
     distinctId: userId,
     event: AnalyticsEvents.InvoicePaymentFailed,
@@ -408,6 +511,8 @@ async function captureFirstInvoicePaidEvent(input: {
 }
 
 export async function POST(req: Request) {
+  let supabase: ServiceSupabaseClient | null = null;
+  let event: Stripe.Event | null = null;
   try {
     console.log('🌐 Incoming Webhook Request:', {
       method: req.method,
@@ -434,7 +539,6 @@ export async function POST(req: Request) {
       console.log('🔑 Processing webhook with idempotency key:', idempotencyKey);
     }
 
-    let event: Stripe.Event
     try {
       console.log('🔍 Verifying webhook signature...');
       event = getStripe().webhooks.constructEvent(body, signature, webhookSecret)
@@ -455,6 +559,10 @@ export async function POST(req: Request) {
       )
     }
 
+    if (!event) {
+      throw new Error('Stripe webhook event was not constructed');
+    }
+
     console.log('📨 Received Stripe Event:', {
       type: event.type,
       id: event.id,
@@ -472,7 +580,7 @@ export async function POST(req: Request) {
       );
     }
 
-    const supabase = await createServiceClient();
+    supabase = await createServiceClient();
     const webhookEventAction = await reserveWebhookEvent(supabase, event);
     if (webhookEventAction === 'skip') {
       console.log('↩️ Duplicate webhook event already processed, skipping:', event.id);
@@ -493,6 +601,7 @@ export async function POST(req: Request) {
         
         if (session.mode === 'subscription' && subscriptionId) {
           const subscriptionData = await handleSubscriptionChange(
+            supabase,
             getCustomerId(session.customer as string | Stripe.Customer | Stripe.DeletedCustomer | null),
             subscriptionId
           );
@@ -518,6 +627,7 @@ export async function POST(req: Request) {
         
         if (subscriptionId) {
           const subscriptionData = await handleSubscriptionChange(
+            supabase,
             getCustomerId(invoice.customer as string | Stripe.Customer | Stripe.DeletedCustomer | null),
             subscriptionId
           );
@@ -537,6 +647,7 @@ export async function POST(req: Request) {
 
         if (subscriptionId) {
           const subscriptionData = await handleSubscriptionChange(
+            supabase,
             getCustomerId(invoice.customer as string | Stripe.Customer | Stripe.DeletedCustomer | null),
             subscriptionId
           );
@@ -563,6 +674,7 @@ export async function POST(req: Request) {
           invoice.next_payment_attempt
         ) {
           const subscriptionData = await handleSubscriptionChange(
+            supabase,
             getCustomerId(invoice.customer as string | Stripe.Customer | Stripe.DeletedCustomer | null),
             subscriptionId
           );
@@ -607,6 +719,7 @@ export async function POST(req: Request) {
         }
         
         const subscriptionData = await handleSubscriptionChange(
+          supabase,
           getCustomerId(subscription.customer),
           subscription.id
         );
@@ -631,6 +744,7 @@ export async function POST(req: Request) {
         });
         
         const subscriptionData = await handleSubscriptionChange(
+          supabase,
           getCustomerId(subscription.customer),
           subscription.id
         );
@@ -686,6 +800,20 @@ export async function POST(req: Request) {
     )
   } catch (err) {
     const error = err instanceof Error ? err : new Error(String(err));
+    if (supabase && event) {
+      await markWebhookEventFailed(supabase, event.id, error);
+      await reportBillingAlert(supabase, {
+        type: 'webhook_processing_failed',
+        severity: 'critical',
+        alertKey: `webhook-failed:${event.id}`,
+        message: `Stripe webhook ${event.type} failed and will be retried by Stripe.`,
+        details: {
+          event_type: event.type,
+          event_id: event.id,
+          error: error.message,
+        },
+      });
+    }
     console.error('🔥 Webhook handler failed:', {
       error: error.message,
       stack: error.stack,

--- a/src/lib/analytics/events.test.ts
+++ b/src/lib/analytics/events.test.ts
@@ -30,6 +30,7 @@ describe("AnalyticsEvents", () => {
     assert.equal(AnalyticsEvents.FirstInvoicePaid, "first_invoice_paid");
     assert.equal(AnalyticsEvents.InvoicePaymentFailed, "invoice_payment_failed");
     assert.equal(AnalyticsEvents.SubscriptionCanceled, "subscription_canceled");
+    assert.equal(AnalyticsEvents.BillingAlertTriggered, "billing_alert_triggered");
     assert.equal(Object.hasOwn(AnalyticsEvents, "SubscriptionActivated"), false);
   });
 });

--- a/src/lib/analytics/events.ts
+++ b/src/lib/analytics/events.ts
@@ -20,6 +20,7 @@ export const AnalyticsEvents = {
   FirstInvoicePaid: "first_invoice_paid",
   InvoicePaymentFailed: "invoice_payment_failed",
   SubscriptionCanceled: "subscription_canceled",
+  BillingAlertTriggered: "billing_alert_triggered",
 } as const;
 
 export type AnalyticsEventName =

--- a/src/lib/billing/alerts.test.ts
+++ b/src/lib/billing/alerts.test.ts
@@ -1,0 +1,41 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+
+import {
+  buildBillingAlertNotification,
+  identifierSuffix,
+  redactBillingAlertDetails,
+} from "./alerts";
+
+describe("billing alerts", () => {
+  it("only exposes identifier suffixes and safe scalar details", () => {
+    assert.equal(identifierSuffix("sub_123456789"), "23456789");
+    assert.deepEqual(
+      redactBillingAlertDetails({
+        stripe_subscription_id: "sub_123456789",
+        email: "person@example.com",
+        attempt_count: 3,
+        error: "payment failed",
+      }),
+      {
+        stripe_subscription_id: "23456789",
+        attempt_count: 3,
+        error: "payment failed",
+      },
+    );
+  });
+
+  it("builds an operator notification without customer PII", () => {
+    const notification = buildBillingAlertNotification({
+      type: "payment_failed",
+      severity: "warning",
+      alertKey: "payment-failed:in_123",
+      message: "Invoice payment failed",
+      stripeSubscriptionId: "sub_123456789",
+      details: { email: "person@example.com", attempt_count: 2 },
+    });
+
+    assert.equal(notification.stripe_subscription_suffix, "23456789");
+    assert.equal(JSON.stringify(notification).includes("person@example.com"), false);
+  });
+});

--- a/src/lib/billing/alerts.ts
+++ b/src/lib/billing/alerts.ts
@@ -1,0 +1,153 @@
+import type { SupabaseClient } from "@supabase/supabase-js";
+
+import { AnalyticsEvents } from "@/lib/analytics/events";
+import { captureServerAnalyticsEvent } from "@/lib/analytics/server";
+
+export type BillingAlertType =
+  | "payment_failed"
+  | "billing_state_mismatch"
+  | "mapping_missing"
+  | "webhook_processing_failed";
+
+export interface BillingAlertInput {
+  type: BillingAlertType;
+  severity: "warning" | "critical";
+  alertKey: string;
+  message: string;
+  stripeSubscriptionId?: string | null;
+  stripeCustomerId?: string | null;
+  details?: Record<string, string | number | boolean | null | undefined>;
+}
+
+const ALERT_COOLDOWN_MS = 15 * 60 * 1000;
+
+export function identifierSuffix(value?: string | null): string | null {
+  if (!value) return null;
+  return value.length <= 8 ? value : value.slice(-8);
+}
+
+export function redactBillingAlertDetails(
+  details: BillingAlertInput["details"] = {},
+): Record<string, string | number | boolean | null> {
+  const output: Record<string, string | number | boolean | null> = {};
+  for (const [key, value] of Object.entries(details)) {
+    if (value === undefined) continue;
+    const lowerKey = key.toLowerCase();
+    if (lowerKey.includes("email") || lowerKey.includes("password")) continue;
+    if (
+      lowerKey.includes("stripe_subscription_id") ||
+      lowerKey.includes("stripe_customer_id") ||
+      lowerKey === "user_id"
+    ) {
+      output[key] = identifierSuffix(String(value));
+    } else if (typeof value === "string") {
+      output[key] = value.slice(0, 240);
+    } else {
+      output[key] = value;
+    }
+  }
+  return output;
+}
+
+export function buildBillingAlertNotification(input: BillingAlertInput) {
+  return {
+    text: `[ResumeLM billing] ${input.severity.toUpperCase()}: ${input.message}`,
+    alert_type: input.type,
+    severity: input.severity,
+    stripe_subscription_suffix: identifierSuffix(input.stripeSubscriptionId),
+    details: redactBillingAlertDetails(input.details),
+  };
+}
+
+function shouldNotify(lastNotifiedAt: string | null | undefined, now: Date) {
+  if (!lastNotifiedAt) return true;
+  const timestamp = Date.parse(lastNotifiedAt);
+  return !Number.isFinite(timestamp) || now.getTime() - timestamp >= ALERT_COOLDOWN_MS;
+}
+
+export async function reportBillingAlert(
+  supabase: SupabaseClient,
+  input: BillingAlertInput,
+): Promise<void> {
+  const now = new Date();
+  const details = redactBillingAlertDetails(input.details);
+  const { data: existing, error: readError } = await supabase
+    .from("billing_alerts")
+    .select("occurrence_count, last_notified_at")
+    .eq("alert_key", input.alertKey)
+    .maybeSingle();
+
+  if (readError) {
+    console.error("Billing alert state lookup failed", { alertType: input.type, error: readError });
+    return;
+  }
+
+  const occurrenceCount = (existing?.occurrence_count ?? 0) + 1;
+  const notify = shouldNotify(existing?.last_notified_at, now);
+  const row = {
+    alert_key: input.alertKey,
+    alert_type: input.type,
+    severity: input.severity,
+    stripe_subscription_id: input.stripeSubscriptionId ?? null,
+    stripe_customer_id: input.stripeCustomerId ?? null,
+    details,
+    occurrence_count: occurrenceCount,
+    first_seen_at: existing ? undefined : now.toISOString(),
+    last_seen_at: now.toISOString(),
+  };
+
+  const { error: writeError } = existing
+    ? await supabase.from("billing_alerts").update(row).eq("alert_key", input.alertKey)
+    : await supabase.from("billing_alerts").insert(row);
+
+  if (writeError) {
+    console.error("Billing alert state write failed", { alertType: input.type, error: writeError });
+    return;
+  }
+
+  let delivered = false;
+  const alertWebhookUrl = process.env.BILLING_ALERT_WEBHOOK_URL;
+  if (notify && alertWebhookUrl) {
+    try {
+      const response = await fetch(alertWebhookUrl, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(buildBillingAlertNotification(input)),
+        cache: "no-store",
+      });
+      delivered = response.ok;
+      if (!response.ok) {
+        console.error("Billing alert webhook rejected notification", {
+          alertType: input.type,
+          status: response.status,
+        });
+      }
+    } catch (error) {
+      console.error("Billing alert webhook delivery failed", {
+        alertType: input.type,
+        error: error instanceof Error ? error.message : "Unknown error",
+      });
+    }
+  }
+
+  if (delivered) {
+    await supabase
+      .from("billing_alerts")
+      .update({ last_notified_at: now.toISOString() })
+      .eq("alert_key", input.alertKey);
+  }
+
+  await captureServerAnalyticsEvent({
+    distinctId: "billing-alerts",
+    event: AnalyticsEvents.BillingAlertTriggered,
+    insertId: `${input.alertKey}:${occurrenceCount}`,
+    properties: {
+      billing_alert_type: input.type,
+      billing_alert_severity: input.severity,
+      billing_alert_occurrence_count: occurrenceCount,
+      billing_alert_webhook_configured: Boolean(alertWebhookUrl),
+      billing_alert_webhook_delivered: delivered,
+      stripe_subscription_suffix: identifierSuffix(input.stripeSubscriptionId),
+    },
+  });
+}

--- a/src/lib/billing/reconciliation.test.ts
+++ b/src/lib/billing/reconciliation.test.ts
@@ -1,0 +1,93 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+
+import { compareStripeAndSupabaseState } from "./reconciliation";
+
+const now = new Date("2026-08-11T12:00:00Z");
+const baseStripe = {
+  id: "sub_12345678",
+  priceId: "price_pro",
+  currentPeriodEnd: "2026-08-29T12:00:00Z",
+  trialEnd: null,
+  cancelAtPeriodEnd: false,
+} as const;
+
+describe("Stripe/Supabase reconciliation", () => {
+  it("accepts a trial mapped to the app's active storage status", () => {
+    assert.equal(
+      compareStripeAndSupabaseState({
+        now,
+        proPriceId: "price_pro",
+        stripe: {
+          ...baseStripe,
+          status: "trialing",
+          trialEnd: "2026-08-12T12:00:00Z",
+          cancelAtPeriodEnd: true,
+        },
+        stored: {
+          user_id: "user_1",
+          stripe_subscription_id: baseStripe.id,
+          subscription_plan: "pro",
+          subscription_status: "canceled",
+          current_period_end: baseStripe.currentPeriodEnd,
+          trial_end: "2026-08-12T12:00:00Z",
+        },
+      }),
+      null,
+    );
+  });
+
+  it("accepts a recoverable past-due subscription", () => {
+    assert.equal(
+      compareStripeAndSupabaseState({
+        now,
+        proPriceId: "price_pro",
+        stripe: { ...baseStripe, status: "past_due" },
+        stored: {
+          user_id: "user_1",
+          stripe_subscription_id: baseStripe.id,
+          subscription_plan: "pro",
+          subscription_status: "past_due",
+          current_period_end: baseStripe.currentPeriodEnd,
+          trial_end: null,
+        },
+      }),
+      null,
+    );
+  });
+
+  it("flags a current Stripe entitlement without a Supabase mapping", () => {
+    const mismatch = compareStripeAndSupabaseState({
+      now,
+      proPriceId: "price_pro",
+      stripe: { ...baseStripe, status: "active" },
+      stored: null,
+    });
+
+    assert.equal(mismatch?.kind, "mapping_missing");
+    assert.equal(mismatch?.severity, "critical");
+  });
+
+  it("flags Pro access when Stripe no longer has the subscription", () => {
+    const mismatch = compareStripeAndSupabaseState({
+      now,
+      proPriceId: "price_pro",
+      stripe: {
+        ...baseStripe,
+        status: "canceled",
+        currentPeriodEnd: null,
+      },
+      stored: {
+        user_id: "user_1",
+        stripe_subscription_id: baseStripe.id,
+        subscription_plan: "pro",
+        subscription_status: "active",
+        current_period_end: baseStripe.currentPeriodEnd,
+        trial_end: null,
+      },
+    });
+
+    assert.equal(mismatch?.kind, "stale_entitlement");
+    assert.equal(mismatch?.severity, "critical");
+  });
+});

--- a/src/lib/billing/reconciliation.ts
+++ b/src/lib/billing/reconciliation.ts
@@ -1,0 +1,130 @@
+import { getBillingState, type BillingState } from "@/lib/billing/state";
+import { getSubscriptionAccessState } from "@/lib/subscription-access";
+import type { SupportedStripeStatus } from "@/lib/stripe/subscription-sync";
+
+export interface StripeReconciliationSnapshot {
+  id: string;
+  priceId: string;
+  status: SupportedStripeStatus;
+  currentPeriodEnd: string | null;
+  trialEnd: string | null;
+  cancelAtPeriodEnd: boolean;
+}
+
+export interface StoredReconciliationSnapshot {
+  user_id: string;
+  stripe_subscription_id: string | null;
+  subscription_plan: string | null;
+  subscription_status: string | null;
+  current_period_end: string | null;
+  trial_end: string | null;
+  payment_failure_count?: number | null;
+}
+
+export type ReconciliationMismatchKind =
+  | "mapping_missing"
+  | "state_mismatch"
+  | "entitlement_mismatch"
+  | "stale_entitlement";
+
+export interface ReconciliationMismatch {
+  kind: ReconciliationMismatchKind;
+  severity: "warning" | "critical";
+  expectedState: BillingState;
+  actualState: BillingState | null;
+  expectedPlan: "pro" | "free";
+  expectedStatus: "active" | "past_due" | "canceled";
+}
+
+function expectedAppState(input: StripeReconciliationSnapshot, proPriceId: string) {
+  const isKnownProPrice = input.priceId === proPriceId;
+  const isActiveLike = input.status === "active" || input.status === "trialing";
+  const isPastDue = input.status === "past_due";
+  const expectedPlan = isKnownProPrice && (isActiveLike || isPastDue) ? "pro" : "free";
+  const expectedStatus =
+    isPastDue
+      ? "past_due"
+      : expectedPlan === "pro" && !input.cancelAtPeriodEnd
+        ? "active"
+        : "canceled";
+
+  return {
+    expectedPlan,
+    expectedStatus,
+    expectedState: getBillingState({
+      plan: expectedPlan,
+      status: expectedStatus,
+      stripeStatus: input.status,
+      currentPeriodEnd: input.currentPeriodEnd,
+      trialEnd: input.trialEnd,
+      cancelAtPeriodEnd: input.cancelAtPeriodEnd,
+    }),
+  } as const;
+}
+
+export function compareStripeAndSupabaseState(input: {
+  stripe: StripeReconciliationSnapshot;
+  stored: StoredReconciliationSnapshot | null;
+  proPriceId: string;
+  now?: Date;
+}): ReconciliationMismatch | null {
+  const now = input.now ?? new Date();
+  const expected = expectedAppState(input.stripe, input.proPriceId);
+
+  // Historical canceled subscriptions do not need a user mapping. Current or
+  // recoverable entitlements do, because missing mappings can strand paid access.
+  if (!input.stored) {
+    return expected.expectedState === "free"
+      ? null
+      : {
+          kind: "mapping_missing",
+          severity: "critical",
+          expectedState: expected.expectedState,
+          actualState: null,
+          expectedPlan: expected.expectedPlan,
+          expectedStatus: expected.expectedStatus,
+        };
+  }
+
+  const actualAccess = getSubscriptionAccessState(input.stored, now);
+  const actualState = actualAccess.billingState;
+
+  if (expected.expectedState === "free" && actualAccess.hasProAccess) {
+    return {
+      kind: "stale_entitlement",
+      severity: "critical",
+      expectedState: expected.expectedState,
+      actualState,
+      expectedPlan: expected.expectedPlan,
+      expectedStatus: expected.expectedStatus,
+    };
+  }
+
+  if (expected.expectedState !== actualState) {
+    return {
+      kind: "state_mismatch",
+      severity: expected.expectedState === "free" && actualState !== "free" ? "critical" : "warning",
+      expectedState: expected.expectedState,
+      actualState,
+      expectedPlan: expected.expectedPlan,
+      expectedStatus: expected.expectedStatus,
+    };
+  }
+
+  if (expected.expectedState !== "free" && !actualAccess.hasProAccess) {
+    return {
+      kind: "entitlement_mismatch",
+      severity: "critical",
+      expectedState: expected.expectedState,
+      actualState,
+      expectedPlan: expected.expectedPlan,
+      expectedStatus: expected.expectedStatus,
+    };
+  }
+
+  return null;
+}
+
+export function getExpectedStripeState(input: StripeReconciliationSnapshot, proPriceId: string) {
+  return expectedAppState(input, proPriceId);
+}

--- a/src/lib/billing/state.test.ts
+++ b/src/lib/billing/state.test.ts
@@ -1,0 +1,69 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+
+import { getBillingState } from "./state";
+
+describe("canonical billing state", () => {
+  const now = new Date("2026-08-11T12:00:00Z");
+
+  it("distinguishes a trial from paid active access", () => {
+    assert.equal(
+      getBillingState({
+        plan: "pro",
+        status: "active",
+        trialEnd: "2026-08-12T12:00:00Z",
+        currentPeriodEnd: "2026-08-12T12:00:00Z",
+      }, now),
+      "trial",
+    );
+    assert.equal(
+      getBillingState({
+        plan: "pro",
+        status: "active",
+        currentPeriodEnd: "2026-09-11T12:00:00Z",
+      }, now),
+      "active",
+    );
+  });
+
+  it("keeps cancel-at-period-end access available but marks it canceling", () => {
+    assert.equal(
+      getBillingState({
+        plan: "pro",
+        status: "canceled",
+        currentPeriodEnd: "2026-08-29T12:00:00Z",
+      }, now),
+      "canceling",
+    );
+  });
+
+  it("keeps past-due access only inside the recoverable window", () => {
+    assert.equal(
+      getBillingState({
+        plan: "pro",
+        status: "past_due",
+        currentPeriodEnd: "2026-08-29T12:00:00Z",
+      }, now),
+      "past_due",
+    );
+    assert.equal(
+      getBillingState({
+        plan: "pro",
+        status: "past_due",
+        currentPeriodEnd: "2026-08-01T12:00:00Z",
+      }, now),
+      "free",
+    );
+  });
+
+  it("does not grant indefinite access from a stale active row", () => {
+    assert.equal(
+      getBillingState({
+        plan: "pro",
+        status: "active",
+        currentPeriodEnd: "2026-08-01T12:00:00Z",
+      }, now),
+      "free",
+    );
+  });
+});

--- a/src/lib/billing/state.ts
+++ b/src/lib/billing/state.ts
@@ -1,0 +1,69 @@
+export type BillingState =
+  | "trial"
+  | "active"
+  | "canceling"
+  | "past_due"
+  | "free";
+
+export interface BillingStateInput {
+  plan?: string | null;
+  status?: string | null;
+  stripeStatus?: string | null;
+  currentPeriodEnd?: string | Date | null;
+  trialEnd?: string | Date | null;
+  cancelAtPeriodEnd?: boolean;
+}
+
+function toDate(value?: string | Date | null): Date | null {
+  if (!value) return null;
+  const parsed = value instanceof Date ? value : new Date(value);
+  return Number.isNaN(parsed.getTime()) ? null : parsed;
+}
+
+function isFuture(value: string | Date | null | undefined, now: Date): boolean {
+  const date = toDate(value);
+  return date !== null && date.getTime() > now.getTime();
+}
+
+export function getBillingState(
+  input: BillingStateInput,
+  now: Date = new Date(),
+): BillingState {
+  const plan = input.plan?.toLowerCase() ?? "";
+  const status = input.status?.toLowerCase() ?? "";
+  const stripeStatus = input.stripeStatus?.toLowerCase() ?? "";
+
+  if (plan !== "pro") return "free";
+
+  const isTrialing =
+    stripeStatus === "trialing" ||
+    (!stripeStatus && status === "active" && isFuture(input.trialEnd, now));
+  const hasFutureAccessWindow =
+    isFuture(input.currentPeriodEnd, now) || isFuture(input.trialEnd, now);
+
+  // A stale database row must never keep Pro access alive indefinitely.
+  if (!hasFutureAccessWindow) return "free";
+
+  if (isTrialing) {
+    return input.cancelAtPeriodEnd ? "canceling" : "trial";
+  }
+
+  if (stripeStatus === "past_due" || status === "past_due") {
+    return "past_due";
+  }
+
+  if (
+    input.cancelAtPeriodEnd ||
+    stripeStatus === "canceled" ||
+    status === "canceled"
+  ) {
+    return "canceling";
+  }
+
+  if (stripeStatus === "active" || status === "active") {
+    return "active";
+  }
+
+  return "free";
+}
+

--- a/src/lib/subscription-access.ts
+++ b/src/lib/subscription-access.ts
@@ -1,3 +1,5 @@
+import { getBillingState, type BillingState } from "@/lib/billing/state";
+
 export interface SubscriptionSnapshot {
   subscription_plan?: string | null;
   subscription_status?: string | null;
@@ -10,6 +12,7 @@ export interface SubscriptionSnapshot {
 }
 
 export interface SubscriptionAccessState {
+  billingState: BillingState;
   isTrialing: boolean;
   isPastDue: boolean;
   isWithinAccessWindow: boolean;
@@ -66,26 +69,29 @@ export function getSubscriptionAccessState(
   const isPastDue = status === "past_due";
   const hasStripeSubscription = Boolean(subscription?.stripe_subscription_id);
   const isWithinAccessWindow = isFutureDate(currentPeriodEnd, now);
-
-  const hasManualProAccess = plan === "pro" && status === "active";
-  const hasTrialingProAccess = plan === "pro" && isTrialing;
-  const hasPastDueProAccess = plan === "pro" && isPastDue && isWithinAccessWindow;
-  const hasCancelingProAccess = plan === "pro" && status === "canceled" && isWithinAccessWindow;
-
-  const hasProAccess =
-    hasManualProAccess || hasTrialingProAccess || hasPastDueProAccess || hasCancelingProAccess;
+  const billingState = getBillingState(
+    {
+      plan,
+      status,
+      currentPeriodEnd,
+      trialEnd,
+    },
+    now,
+  );
+  const hasProAccess = billingState !== "free";
 
   const hadPaidAccess = plan === "pro";
-  const isCanceling = status === "canceled" && isWithinAccessWindow;
+  const isCanceling = billingState === "canceling";
   const isExpiredProAccess =
-    (status === "canceled" || status === "past_due") &&
-    !isWithinAccessWindow &&
-    hadPaidAccess;
+    hadPaidAccess &&
+    !hasProAccess &&
+    ["active", "canceled", "past_due"].includes(status);
 
   const hasSubscriptionRecord = Boolean(subscription);
   const effectivePlan = hasSubscriptionRecord ? (hasProAccess ? "pro" : "free") : "";
 
   return {
+    billingState,
     isTrialing,
     isPastDue,
     isWithinAccessWindow,

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -27,11 +27,12 @@ export const config = {
      * - _next/image (image optimization files)
      * - favicon.ico (favicon file)
      * - api/webhooks (webhook endpoints)
+     * - api/cron (Vercel cron endpoints authenticate with their own secret)
      * - api/ai/model-health (public, read-only health snapshot)
      * - blog (blog section)
      * - public metadata and media files
      * Run on all other routes to protect them
      */
-    '/((?!_next/static|_next/image|favicon.ico|robots.txt|sitemap.xml|api/webhooks|api/ai/model-health|blog(?:/.*)?|.*\\.(?:svg|png|jpg|jpeg|gif|webp|mp4|webm|mov|m4v|ogv)$).*)',
+    '/((?!_next/static|_next/image|favicon.ico|robots.txt|sitemap.xml|api/webhooks|api/cron|api/ai/model-health|blog(?:/.*)?|.*\\.(?:svg|png|jpg|jpeg|gif|webp|mp4|webm|mov|m4v|ogv)$).*)',
   ],
 }

--- a/supabase/migrations/20260811210000_billing_reconciliation_and_alerts.sql
+++ b/supabase/migrations/20260811210000_billing_reconciliation_and_alerts.sql
@@ -1,0 +1,76 @@
+-- Track webhook attempts and operational failures without changing entitlement data.
+ALTER TABLE public.stripe_webhook_events
+  ADD COLUMN IF NOT EXISTS status text NOT NULL DEFAULT 'processing',
+  ADD COLUMN IF NOT EXISTS attempt_count integer NOT NULL DEFAULT 1,
+  ADD COLUMN IF NOT EXISTS last_attempt_at timestamp with time zone,
+  ADD COLUMN IF NOT EXISTS last_error text,
+  ADD COLUMN IF NOT EXISTS event_created_at timestamp with time zone;
+
+UPDATE public.stripe_webhook_events
+SET
+  status = CASE WHEN processed_at IS NULL THEN 'failed' ELSE 'processed' END,
+  last_attempt_at = COALESCE(last_attempt_at, updated_at),
+  event_created_at = COALESCE(event_created_at, created_at)
+WHERE status = 'processing';
+
+ALTER TABLE public.stripe_webhook_events
+  DROP CONSTRAINT IF EXISTS stripe_webhook_events_status_check;
+
+ALTER TABLE public.stripe_webhook_events
+  ADD CONSTRAINT stripe_webhook_events_status_check
+  CHECK (status = ANY (ARRAY['processing'::text, 'processed'::text, 'failed'::text]));
+
+ALTER TABLE public.stripe_webhook_events
+  DROP CONSTRAINT IF EXISTS stripe_webhook_events_attempt_count_nonnegative;
+
+ALTER TABLE public.stripe_webhook_events
+  ADD CONSTRAINT stripe_webhook_events_attempt_count_nonnegative
+  CHECK (attempt_count > 0);
+
+CREATE INDEX IF NOT EXISTS stripe_webhook_events_retry_idx
+  ON public.stripe_webhook_events (status, last_attempt_at);
+
+CREATE TABLE IF NOT EXISTS public.billing_alerts (
+  alert_key text NOT NULL,
+  alert_type text NOT NULL,
+  severity text NOT NULL,
+  stripe_subscription_id text NULL,
+  stripe_customer_id text NULL,
+  details jsonb NOT NULL DEFAULT '{}'::jsonb,
+  occurrence_count integer NOT NULL DEFAULT 1,
+  first_seen_at timestamp with time zone NOT NULL DEFAULT timezone('utc'::text, now()),
+  last_seen_at timestamp with time zone NOT NULL DEFAULT timezone('utc'::text, now()),
+  last_notified_at timestamp with time zone NULL,
+  resolved_at timestamp with time zone NULL,
+  updated_at timestamp with time zone NOT NULL DEFAULT timezone('utc'::text, now()),
+  CONSTRAINT billing_alerts_pkey PRIMARY KEY (alert_key),
+  CONSTRAINT billing_alerts_type_check CHECK (
+    alert_type = ANY (ARRAY[
+      'payment_failed'::text,
+      'billing_state_mismatch'::text,
+      'mapping_missing'::text,
+      'webhook_processing_failed'::text
+    ])
+  ),
+  CONSTRAINT billing_alerts_severity_check CHECK (
+    severity = ANY (ARRAY['warning'::text, 'critical'::text])
+  ),
+  CONSTRAINT billing_alerts_occurrence_count_positive CHECK (occurrence_count > 0)
+);
+
+DROP TRIGGER IF EXISTS update_billing_alerts_updated_at ON public.billing_alerts;
+
+CREATE TRIGGER update_billing_alerts_updated_at
+BEFORE UPDATE ON public.billing_alerts
+FOR EACH ROW
+EXECUTE FUNCTION update_updated_at_column();
+
+CREATE INDEX IF NOT EXISTS billing_alerts_open_idx
+  ON public.billing_alerts (resolved_at, severity, last_seen_at);
+
+ALTER TABLE public.billing_alerts ENABLE ROW LEVEL SECURITY;
+REVOKE ALL ON TABLE public.billing_alerts FROM anon, authenticated;
+GRANT ALL ON TABLE public.billing_alerts TO service_role;
+
+COMMENT ON TABLE public.billing_alerts IS
+  'Deduplicated Stripe/Supabase billing alerts for operational monitoring.';

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,8 @@
+{
+  "crons": [
+    {
+      "path": "/api/cron/billing-reconciliation",
+      "schedule": "0 * * * *"
+    }
+  ]
+}


### PR DESCRIPTION
## What changed

- Define canonical billing states for trial, active, canceling, past_due, and free access.
- Prevent stale active Pro rows from granting indefinite access after their entitlement window expires.
- Add a protected hourly reconciliation endpoint that compares all Stripe subscriptions with Stripe-linked Supabase rows and alerts on current-state drift.
- Persist webhook attempt status and failure details instead of only processed/unprocessed state.
- Alert on failed invoice payments, missing Stripe-to-Supabase mappings, webhook processing failures, and entitlement mismatches.
- Keep alert payloads deduplicated and redacted; optionally deliver them to a Slack/Discord-compatible webhook.
- Exclude the cron endpoint from session middleware so Vercel cron can authenticate with CRON_SECRET.
- Add matching migrations, local schema/Helm/Docker definitions, Vercel cron configuration, and unit coverage.

## Why

Stripe currently has a recoverable past-due subscription and a trial ending without paid conversion. The existing app state correctly reflects those two records, but webhook failures and state drift were not observable, and historical Stripe/Supabase linkage was not continuously checked.

## Validation

- pnpm typecheck
- pnpm test (103 passing)
- pnpm lint
- pnpm check:trust
- pnpm build
- Local HTTP checks: marketing page 200, cron without secret 401, cron with secret reaches the reconciliation handler.
- Supabase migration applied and verified in production; RLS remains enabled and service-role-only for operational tables.

## Deployment configuration

Set CRON_SECRET in the deployed environment. Set BILLING_ALERT_WEBHOOK_URL to enable external operator notifications; without it, alerts remain persisted and logged/PostHog-captured.