### PR TITLE
fix: repair analytics lifecycle and privacy telemetry

### DIFF
--- a/src/app/(auth)/auth/callback/route.ts
+++ b/src/app/(auth)/auth/callback/route.ts
@@ -164,10 +164,34 @@ export async function GET(request: NextRequest) {
     await captureServerAnalyticsEvent({
       distinctId: oauthUser.id,
       event: AnalyticsEvents.SignupCompleted,
+      insertId: `${oauthUser.id}:${AnalyticsEvents.SignupCompleted}`,
       properties: {
         signup_provider: 'google',
       },
     })
+  }
+
+  const { data: userData } = await supabase.auth.getUser()
+  if (userData.user) {
+    await Promise.all([
+      captureServerAnalyticsEvent({
+        distinctId: userData.user.id,
+        event: AnalyticsEvents.AuthSucceeded,
+        insertId: `${userData.user.id}:auth_succeeded:oauth`,
+        properties: {
+          auth_method: "google",
+          auth_flow: "oauth",
+        },
+      }),
+      captureServerAnalyticsEvent({
+        distinctId: userData.user.id,
+        event: AnalyticsEvents.OAuthCompleted,
+        insertId: `${userData.user.id}:oauth_completed`,
+        properties: {
+          oauth_provider: "google",
+        },
+      }),
+    ])
   }
 
   const redirectPath = getAuthRedirectPath(intent)

--- a/src/app/(auth)/auth/confirm/route.ts
+++ b/src/app/(auth)/auth/confirm/route.ts
@@ -4,6 +4,8 @@ import { type NextRequest } from 'next/server'
 import { createClient } from '@/utils/supabase/server'
 import { redirect } from 'next/navigation'
 import { getSafeRedirectPath } from '@/lib/auth-intent'
+import { AnalyticsEvents } from '@/lib/analytics/events'
+import { captureServerAnalyticsEvent } from '@/lib/analytics/server'
 
 export async function GET(request: NextRequest) {
   const { searchParams } = new URL(request.url)
@@ -14,11 +16,21 @@ export async function GET(request: NextRequest) {
   if (token_hash && type) {
     const supabase = await createClient()
 
-    const { error } = await supabase.auth.verifyOtp({
+    const { data, error } = await supabase.auth.verifyOtp({
       type,
       token_hash,
     })
     if (!error) {
+      if (data.user) {
+        await captureServerAnalyticsEvent({
+          distinctId: data.user.id,
+          event: AnalyticsEvents.EmailConfirmationCompleted,
+          insertId: `${data.user.id}:email_confirmation_completed`,
+          properties: {
+            confirmation_type: type,
+          },
+        });
+      }
       // redirect user to specified redirect URL or root of app
       redirect(getSafeRedirectPath(next, '/'))
     }

--- a/src/app/(auth)/auth/login/actions.ts
+++ b/src/app/(auth)/auth/login/actions.ts
@@ -6,7 +6,7 @@ import { getAuthenticatedClient, getServiceClient } from "@/utils/actions/utils/
 import { deleteCustomerAndData } from "@/utils/actions/stripe/actions";
 import { loginSchema, signupSchema } from "@/lib/auth-schemas";
 import type { AuthFormState } from "@/components/auth/auth-form-state";
-import { AnalyticsEvents } from "@/lib/analytics/events";
+import { AnalyticsEvents, buildAnalyticsInsertId } from "@/lib/analytics/events";
 import { captureServerAnalyticsEvent } from "@/lib/analytics/server";
 import { getEmailSignupBlockedMessage, isEmailSignupAllowed } from "@/lib/auth-policy";
 import {
@@ -58,7 +58,7 @@ export async function login(formData: FormData): Promise<AuthResult> {
     password: formData.get('password') as string,
   }
 
-  const { error } = await supabase.auth.signInWithPassword(data)
+  const { data: signInData, error } = await supabase.auth.signInWithPassword(data)
 
   if (error) {
     console.error('Password sign-in failed:', {
@@ -68,6 +68,18 @@ export async function login(formData: FormData): Promise<AuthResult> {
       name: error.name,
     });
     return { success: false, error: mapLoginErrorMessage(error.message), errorCode: error.code };
+  }
+
+  if (signInData.user) {
+    await captureServerAnalyticsEvent({
+      distinctId: signInData.user.id,
+      event: AnalyticsEvents.AuthSucceeded,
+      insertId: `${signInData.user.id}:auth_succeeded:login`,
+      properties: {
+        auth_method: "email",
+        auth_flow: "login",
+      },
+    });
   }
 
   const next = getAuthRedirectPath(getAuthIntentFromParams({
@@ -133,8 +145,18 @@ export async function signup(formData: FormData): Promise<AuthResult> {
     await captureServerAnalyticsEvent({
       distinctId: signupData.user.id,
       event: AnalyticsEvents.SignupCompleted,
+      insertId: buildAnalyticsInsertId(signupData.user.id, AnalyticsEvents.SignupCompleted),
       properties: {
         signup_provider: "email",
+      },
+    });
+    await captureServerAnalyticsEvent({
+      distinctId: signupData.user.id,
+      event: AnalyticsEvents.AuthSucceeded,
+      insertId: `${signupData.user.id}:auth_succeeded:signup`,
+      properties: {
+        auth_method: "email",
+        auth_flow: "signup",
       },
     });
   }

--- a/src/app/(dashboard)/subscription/checkout/success/page.tsx
+++ b/src/app/(dashboard)/subscription/checkout/success/page.tsx
@@ -1,27 +1,72 @@
-// /src/app/checkout/success/page.tsx
+import Stripe from "stripe";
+import { redirect } from "next/navigation";
 
-const SuccessPage = () => {
-    return (
-        <div className="text-center space-y-4 p-8 max-w-2xl mx-auto">
-            <div className="space-y-2">
-                <h1 className="text-3xl font-bold bg-gradient-to-r from-purple-600 to-indigo-600 bg-clip-text text-transparent">
-                    Payment Successful!
-                </h1>
-                <p className="text-muted-foreground">
-                    Your subscription has been activated. You now have full access to ResumeLM&apos;s premium features.
-                </p>
-            </div>
-            
-            <div className="mt-6 p-6 bg-white/40 backdrop-blur-md rounded-2xl border border-white/40 shadow-xl">
-                <h3 className="text-lg font-semibold mb-4">Next Steps</h3>
-                <div className="space-y-2 text-sm">
-                    <p>✓ Access to AI-powered resume tailoring</p>
-                    <p>✓ Unlimited resume versions</p>
-                    <p>✓ App-funded premium AI models</p>
-                </div>
-            </div>
-        </div>
-    )
+import { createClient } from "@/utils/supabase/server";
+import { getSubscriptionAccessState } from "@/lib/subscription-access";
+
+function getStripeClient() {
+  const secretKey = process.env.STRIPE_SECRET_KEY;
+  if (!secretKey) return null;
+
+  return new Stripe(secretKey, {
+    apiVersion: "2025-04-30.basil",
+  });
 }
 
-export default SuccessPage
+export default async function SuccessPage({
+  searchParams,
+}: {
+  searchParams: Promise<{ session_id?: string }>;
+}) {
+  const { session_id: sessionId } = await searchParams;
+  const supabase = await createClient();
+  const { data: { user } } = await supabase.auth.getUser();
+
+  if (!user || !sessionId) {
+    redirect("/subscription");
+  }
+
+  let sessionBelongsToUser = false;
+  const stripe = getStripeClient();
+  if (stripe) {
+    try {
+      const session = await stripe.checkout.sessions.retrieve(sessionId);
+      const sessionUserId = session.metadata?.supabaseUUID ?? session.client_reference_id;
+      sessionBelongsToUser = session.status === "complete" && sessionUserId === user.id;
+    } catch {
+      sessionBelongsToUser = false;
+    }
+  }
+
+  const { data: subscription } = await supabase
+    .from("subscriptions")
+    .select("subscription_plan, subscription_status, stripe_subscription_id, current_period_end, trial_end")
+    .eq("user_id", user.id)
+    .maybeSingle();
+
+  const entitlementActive = sessionBelongsToUser && getSubscriptionAccessState(subscription).hasProAccess;
+
+  return (
+    <div className="text-center space-y-4 p-8 max-w-2xl mx-auto">
+      <div className="space-y-2">
+        <h1 className="text-3xl font-bold bg-gradient-to-r from-purple-600 to-indigo-600 bg-clip-text text-transparent">
+          {entitlementActive ? "Subscription active" : "Payment received"}
+        </h1>
+        <p className="text-muted-foreground">
+          {entitlementActive
+            ? "Your Pro access is active."
+            : "Stripe received your payment. We are confirming your subscription now; refresh this page in a moment if access has not appeared yet."}
+        </p>
+      </div>
+
+      <div className="mt-6 p-6 bg-white/40 backdrop-blur-md rounded-2xl border border-white/40 shadow-xl">
+        <h3 className="text-lg font-semibold mb-4">Next Steps</h3>
+        <div className="space-y-2 text-sm">
+          <p>✓ Access to AI-powered resume tailoring</p>
+          <p>✓ Unlimited resume versions</p>
+          <p>✓ App-funded premium AI models</p>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/app/(dashboard)/subscription/stripe-session.tsx
+++ b/src/app/(dashboard)/subscription/stripe-session.tsx
@@ -4,6 +4,8 @@ import { Stripe } from "stripe";
 import { checkAuth } from "@/app/(auth)/auth/login/actions";
 import { getServerAnalyticsContext } from "@/lib/analytics/server";
 import { createOrRetrieveCustomer } from "@/utils/actions/stripe/actions";
+import { AnalyticsEvents } from "@/lib/analytics/events";
+import { captureServerAnalyticsEvent } from "@/lib/analytics/server";
 import {
     buildCheckoutIdempotencyKey,
     buildCheckoutSessionMetadata,
@@ -12,10 +14,18 @@ import {
     isMatchingOpenCheckoutSession,
 } from "@/lib/stripe/checkout-guard";
 
-const apiKey = process.env.STRIPE_SECRET_KEY as string;
-const stripe = new Stripe(apiKey, {
-    apiVersion: "2025-04-30.basil",
-});
+let stripeClient: Stripe | null = null;
+
+function getStripeClient() {
+    if (!stripeClient) {
+        const apiKey = process.env.STRIPE_SECRET_KEY;
+        if (!apiKey) throw new Error("STRIPE_SECRET_KEY is not configured");
+        stripeClient = new Stripe(apiKey, {
+            apiVersion: "2025-04-30.basil",
+        });
+    }
+    return stripeClient;
+}
 
 interface NewSessionOptions {
     priceId: string;
@@ -27,10 +37,39 @@ export type StripeSessionResult =
     | { kind: "portal"; url: string; reason: "existing_subscription" }
     | { kind: "error"; message: string };
 
+function getCheckoutErrorCategory(error: unknown): string {
+    const message = error instanceof Error ? error.message.toLowerCase() : "";
+    if (message.includes("price") || message.includes("valid")) return "invalid_checkout_configuration";
+    if (message.includes("customer")) return "customer_lookup_failed";
+    if (message.includes("stripe")) return "stripe_session_creation_failed";
+    return "checkout_session_creation_failed";
+}
+
+async function captureCheckoutStarted(input: {
+    userId: string;
+    sessionId: string;
+    priceId: string;
+    includeTrial: boolean;
+    context: Awaited<ReturnType<typeof getServerAnalyticsContext>>;
+}) {
+    await captureServerAnalyticsEvent({
+        distinctId: input.userId,
+        event: AnalyticsEvents.CheckoutStarted,
+        insertId: `${input.sessionId}:${AnalyticsEvents.CheckoutStarted}`,
+        context: input.context,
+        properties: {
+            price_id: input.priceId,
+            include_trial: input.includeTrial,
+            checkout_surface: "embedded",
+            stripe_checkout_session_id: input.sessionId,
+        },
+    });
+}
+
 async function createBillingPortalSession(customerId: string) {
     const returnUrl = `${process.env.NEXT_PUBLIC_SITE_URL}/subscription`;
 
-    return stripe.billingPortal.sessions.create({
+    return getStripeClient().billingPortal.sessions.create({
         customer: customerId,
         return_url: returnUrl,
     });
@@ -52,6 +91,15 @@ export const postStripeSession = async ({ priceId, includeTrial = false }: NewSe
         }
 
         if (priceId !== proPriceId) {
+            await captureServerAnalyticsEvent({
+                distinctId: user.id,
+                event: AnalyticsEvents.CheckoutError,
+                properties: {
+                    price_id: priceId,
+                    include_trial: includeTrial,
+                    error_category: "invalid_checkout_configuration",
+                },
+            });
             return {
                 kind: "error",
                 message: "This checkout link is no longer valid. Please restart checkout from the subscription page.",
@@ -64,7 +112,7 @@ export const postStripeSession = async ({ priceId, includeTrial = false }: NewSe
             email: user.email
         });
 
-        const existingSubscriptions = await stripe.subscriptions.list({
+        const existingSubscriptions = await getStripeClient().subscriptions.list({
             customer: customerId,
             price: priceId,
             status: "all",
@@ -100,7 +148,7 @@ export const postStripeSession = async ({ priceId, includeTrial = false }: NewSe
             analyticsContext,
         });
 
-        const openSessions = await stripe.checkout.sessions.list({
+        const openSessions = await getStripeClient().checkout.sessions.list({
             customer: customerId,
             status: "open",
             limit: 10,
@@ -117,6 +165,15 @@ export const postStripeSession = async ({ priceId, includeTrial = false }: NewSe
                 sessionId: reusableSession.id,
                 priceId,
                 includeTrial,
+                context: analyticsContext,
+            });
+
+            await captureCheckoutStarted({
+                userId: user.id,
+                sessionId: reusableSession.id,
+                priceId,
+                includeTrial,
+                context: analyticsContext,
             });
 
             return {
@@ -134,7 +191,7 @@ export const postStripeSession = async ({ priceId, includeTrial = false }: NewSe
             returnUrl
         });
 
-        const session = await stripe.checkout.sessions.create({
+        const session = await getStripeClient().checkout.sessions.create({
             customer: customerId,
             ui_mode: "embedded",
             line_items: [
@@ -173,11 +230,28 @@ export const postStripeSession = async ({ priceId, includeTrial = false }: NewSe
             throw new Error('Failed to create Stripe session');
         }
 
+        await captureCheckoutStarted({
+            userId: user.id,
+            sessionId: session.id,
+            priceId,
+            includeTrial,
+            context: analyticsContext,
+        });
+
         return {
             kind: "checkout",
             clientSecret: session.client_secret
         };
     } catch (error) {
+        await captureServerAnalyticsEvent({
+            distinctId: user.id,
+            event: AnalyticsEvents.CheckoutError,
+            properties: {
+                price_id: priceId,
+                include_trial: includeTrial,
+                error_category: getCheckoutErrorCategory(error),
+            },
+        });
         console.error('Error creating checkout session:', error);
         throw new Error(error instanceof Error ? error.message : 'Failed to create checkout session');
     }

--- a/src/app/api/webhooks/stripe/route.ts
+++ b/src/app/api/webhooks/stripe/route.ts
@@ -287,6 +287,19 @@ async function handleSubscriptionChange(
         },
       });
     }
+
+    if (
+      subscriptionData.user_id &&
+      subscriptionData.subscription_plan === 'pro' &&
+      subscriptionData.subscription_status === 'active'
+    ) {
+      await captureServerAnalyticsEvent({
+        distinctId: subscriptionData.user_id,
+        event: AnalyticsEvents.EntitlementActivated,
+        insertId: `${subscriptionId}:${AnalyticsEvents.EntitlementActivated}`,
+        properties: getSubscriptionEventProperties(subscriptionData, 'entitlement.activated'),
+      });
+    }
     
     console.log('✨ Final Subscription State:', {
       result: 'success',

--- a/src/components/analytics/posthog-pageview.tsx
+++ b/src/components/analytics/posthog-pageview.tsx
@@ -22,6 +22,12 @@ export function PostHogPageView({ userId }: { userId?: string | null }) {
   useEffect(() => {
     if (!pathname) return;
 
+    // Identify before capturing the first authenticated pageview so browser
+    // events and server-side lifecycle events share the Supabase user UUID.
+    if (userId) {
+      posthog.identify(userId);
+    }
+
     const search = searchParams.toString();
     const currentUrl =
       search.length > 0

--- a/src/components/analytics/posthog-provider.tsx
+++ b/src/components/analytics/posthog-provider.tsx
@@ -59,11 +59,11 @@ export function PostHogProvider({
     // checkout/editor events cannot accidentally stay on an anonymous ID.
     const anonymousId = readBrowserAnalyticsAnonymousId();
     posthog.identify(user.id, sanitizeAnalyticsProperties({
+      analytics_user_id: user.id,
       subscription_plan: user.subscriptionPlan,
       subscription_status: user.subscriptionStatus,
       is_pro: user.isPro,
       analytics_anonymous_id: anonymousId,
-      analytics_user_id: user.id,
     }));
     activeIdentifiedUserId = user.id;
     posthog.register({

--- a/src/components/auth/auth-dialog-provider.tsx
+++ b/src/components/auth/auth-dialog-provider.tsx
@@ -10,6 +10,8 @@ import { Alert, AlertDescription } from "@/components/ui/alert";
 import { Button } from "@/components/ui/button";
 import { Dialog, DialogContent, DialogDescription, DialogTitle } from "@/components/ui/dialog";
 import { Separator } from "@/components/ui/separator";
+import { usePostHog } from "posthog-js/react";
+import { AnalyticsEvents } from "@/lib/analytics/events";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import type { AuthIntent } from "@/lib/auth-intent";
 
@@ -40,12 +42,25 @@ function TabButton({ value, children }: { value: AuthTab; children: React.ReactN
   );
 }
 
-function SocialAuth({ showDivider = true, intent }: { showDivider?: boolean; intent?: AuthIntent }) {
+function SocialAuth({
+  showDivider = true,
+  intent,
+  authFlow,
+}: {
+  showDivider?: boolean;
+  intent?: AuthIntent;
+  authFlow: AuthTab;
+}) {
   const [isLoading, setIsLoading] = useState(false);
   const [errorMessage, setErrorMessage] = useState<string>();
+  const posthog = usePostHog();
 
   const handleGoogleSignIn = async () => {
     setErrorMessage(undefined);
+    posthog?.capture(AnalyticsEvents.AuthStarted, {
+      auth_method: "google",
+      auth_flow: authFlow,
+    });
 
     try {
       setIsLoading(true);
@@ -205,7 +220,7 @@ export function AuthDialogProvider({
                     next={intent?.next ?? (intent?.plan === "pro" ? "/subscription" : undefined)}
                     plan={intent?.plan}
                   />
-                  <SocialAuth intent={intent} />
+                  <SocialAuth intent={intent} authFlow="login" />
                 </TabsContent>
 
                 <TabsContent value="signup" className="mt-0 space-y-4">
@@ -218,7 +233,7 @@ export function AuthDialogProvider({
                     next={intent?.next ?? (intent?.plan === "pro" ? "/subscription" : undefined)}
                     plan={intent?.plan}
                   />
-                  <SocialAuth intent={intent} />
+                  <SocialAuth intent={intent} authFlow="signup" />
                 </TabsContent>
               </div>
             </Tabs>

--- a/src/components/auth/login-form.tsx
+++ b/src/components/auth/login-form.tsx
@@ -3,6 +3,7 @@
 import Link from "next/link";
 import { useActionState, useState } from "react";
 import { useFormStatus } from "react-dom";
+import { usePostHog } from "posthog-js/react";
 import { Eye, EyeOff, Loader2 } from "lucide-react";
 
 import { loginWithState } from "@/app/(auth)/auth/login/actions";
@@ -11,6 +12,7 @@ import { Alert, AlertDescription } from "@/components/ui/alert";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
+import { AnalyticsEvents } from "@/lib/analytics/events";
 
 function SubmitButton() {
   const { pending } = useFormStatus();
@@ -36,12 +38,22 @@ function SubmitButton() {
 export function LoginForm({ next, plan }: { next?: string; plan?: "free" | "pro" }) {
   const [state, formAction] = useActionState(loginWithState, initialAuthFormState);
   const [showPassword, setShowPassword] = useState(false);
+  const posthog = usePostHog();
 
   const emailError = state.fieldErrors?.email?.[0];
   const passwordError = state.fieldErrors?.password?.[0];
 
   return (
-    <form action={formAction} className="space-y-5">
+    <form
+      action={formAction}
+      className="space-y-5"
+      onSubmit={() => {
+        posthog?.capture(AnalyticsEvents.AuthStarted, {
+          auth_method: "email",
+          auth_flow: "login",
+        });
+      }}
+    >
       {next && <input type="hidden" name="next" value={next} />}
       {plan && <input type="hidden" name="plan" value={plan} />}
       <div className="space-y-2">

--- a/src/components/auth/signup-form.tsx
+++ b/src/components/auth/signup-form.tsx
@@ -2,6 +2,7 @@
 
 import { useActionState, useEffect, useRef, useState } from "react";
 import { useFormStatus } from "react-dom";
+import { usePostHog } from "posthog-js/react";
 import { CheckCircle2, Eye, EyeOff, Loader2 } from "lucide-react";
 
 import { signupWithState } from "@/app/(auth)/auth/login/actions";
@@ -10,6 +11,7 @@ import { Alert, AlertDescription } from "@/components/ui/alert";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
+import { AnalyticsEvents } from "@/lib/analytics/events";
 
 interface SignupFormProps {
   onSuccess?: () => void;
@@ -42,6 +44,7 @@ export function SignupForm({ onSuccess, next, plan }: SignupFormProps) {
   const [state, formAction] = useActionState(signupWithState, initialAuthFormState);
   const [showPassword, setShowPassword] = useState(false);
   const hasHandledSuccess = useRef(false);
+  const posthog = usePostHog();
 
   useEffect(() => {
     if (!onSuccess || state.status !== "success" || hasHandledSuccess.current) return;
@@ -72,7 +75,16 @@ export function SignupForm({ onSuccess, next, plan }: SignupFormProps) {
   }
 
   return (
-    <form action={formAction} className="space-y-4">
+    <form
+      action={formAction}
+      className="space-y-4"
+      onSubmit={() => {
+        posthog?.capture(AnalyticsEvents.AuthStarted, {
+          auth_method: "email",
+          auth_flow: "signup",
+        });
+      }}
+    >
       {next && <input type="hidden" name="next" value={next} />}
       {plan && <input type="hidden" name="plan" value={plan} />}
       <div className="space-y-2">

--- a/src/components/checkout-form.tsx
+++ b/src/components/checkout-form.tsx
@@ -28,7 +28,7 @@ export function CheckoutForm() {
     const [errorMessage, setErrorMessage] = React.useState<string | null>(null);
 
     const captureCheckoutEvent = React.useCallback((
-        event: typeof AnalyticsEvents.CheckoutViewed | typeof AnalyticsEvents.CheckoutError | typeof AnalyticsEvents.CheckoutStarted,
+        event: typeof AnalyticsEvents.CheckoutViewed | typeof AnalyticsEvents.CheckoutError,
         properties: Record<string, string | number | boolean | null | undefined> = {},
     ) => {
         if (!posthog) return;
@@ -80,16 +80,10 @@ export function CheckoutForm() {
 
                 if (stripeResponse.kind === "error") {
                     setErrorMessage(stripeResponse.message);
-                    captureCheckoutEvent(AnalyticsEvents.CheckoutError, {
-                        error_code: "invalid_checkout_link",
-                    });
                     return;
                 }
 
                 setClientSecret(stripeResponse.clientSecret);
-                captureCheckoutEvent(AnalyticsEvents.CheckoutStarted, {
-                    checkout_surface: "embedded",
-                });
             } catch (error) {
                 if (!isMounted) return;
 
@@ -98,9 +92,6 @@ export function CheckoutForm() {
                         ? error.message
                         : "Unable to start checkout. Please try again."
                 );
-                captureCheckoutEvent(AnalyticsEvents.CheckoutError, {
-                    error_code: "session_creation_failed",
-                });
             }
         }
 

--- a/src/components/pricing/optimized-subscription-page.tsx
+++ b/src/components/pricing/optimized-subscription-page.tsx
@@ -71,7 +71,7 @@ export function OptimizedSubscriptionPage({ initialProfile }: OptimizedSubscript
       // Handle checkout for free users
       const priceId = process.env.NEXT_PUBLIC_STRIPE_PRO_PRICE_ID;
       if (priceId) {
-        router.push(`/subscription/checkout?price_id=${priceId}`);
+        router.push(`/subscription/checkout?price_id=${priceId}&trial=true`);
       }
     }
   };

--- a/src/lib/ai/posthog-telemetry.test.ts
+++ b/src/lib/ai/posthog-telemetry.test.ts
@@ -3,6 +3,7 @@ import { afterEach, describe, it } from "node:test";
 
 import type { ResolvedAIRequest } from "./access-control";
 import { buildPostHogAITelemetry } from "./posthog-telemetry";
+import { getAIErrorCategory } from "./usage-ledger";
 
 const ORIGINAL_ENV = {
   NEXT_PUBLIC_POSTHOG_KEY: process.env.NEXT_PUBLIC_POSTHOG_KEY,
@@ -74,7 +75,7 @@ describe("buildPostHogAITelemetry", () => {
     );
   });
 
-  it("enables full input and output capture with ResumeLM metadata", () => {
+  it("keeps AI metadata while disabling input and output capture", () => {
     process.env.NEXT_PUBLIC_POSTHOG_KEY = "phc_test";
     delete process.env.POSTHOG_LLM_ANALYTICS_DISABLED;
 
@@ -88,8 +89,8 @@ describe("buildPostHogAITelemetry", () => {
     });
 
     assert.equal(telemetry.isEnabled, true);
-    assert.equal(telemetry.recordInputs, true);
-    assert.equal(telemetry.recordOutputs, true);
+    assert.equal(telemetry.recordInputs, false);
+    assert.equal(telemetry.recordOutputs, false);
     assert.equal(telemetry.functionId, "actions.resumes.generateResumeScore");
     assert.deepEqual(telemetry.metadata, {
       posthog_distinct_id: "user_123",
@@ -97,10 +98,6 @@ describe("buildPostHogAITelemetry", () => {
       resumelm_route: "actions.resumes.generateResumeScore",
       resumelm_provider: "openai",
       resumelm_model: "gpt-5.4-mini",
-      resumelm_is_pro: true,
-      resumelm_used_server_key: true,
-      resumelm_requires_rate_limit: true,
-      resumelm_environment: "test",
     });
   });
 
@@ -121,5 +118,15 @@ describe("buildPostHogAITelemetry", () => {
     assert.equal("apiKey" in telemetry.metadata, false);
     assert.equal("api_key" in telemetry.metadata, false);
     assert.equal("provider-secret" in telemetry.metadata, false);
+  });
+});
+
+describe("getAIErrorCategory", () => {
+  it("maps provider failures to bounded categories without retaining raw messages", () => {
+    assert.equal(getAIErrorCategory("You exceeded your current quota"), "provider_billing");
+    assert.equal(getAIErrorCategory("OpenAI API key not found in user configuration"), "provider_authentication");
+    assert.equal(getAIErrorCategory("No object generated: response did not match schema"), "invalid_model_output");
+    assert.equal(getAIErrorCategory("Unexpected provider failure"), "provider_error");
+    assert.equal(getAIErrorCategory(undefined), null);
   });
 });

--- a/src/lib/ai/posthog-telemetry.ts
+++ b/src/lib/ai/posthog-telemetry.ts
@@ -41,8 +41,8 @@ export function buildPostHogAITelemetry(input: {
 
   return {
     isEnabled: true,
-    recordInputs: true,
-    recordOutputs: true,
+    recordInputs: false,
+    recordOutputs: false,
     functionId: input.route,
     metadata: {
       posthog_distinct_id: input.userId,
@@ -50,10 +50,6 @@ export function buildPostHogAITelemetry(input: {
       resumelm_route: input.route,
       resumelm_provider: input.resolved.providerId,
       resumelm_model: input.resolved.modelId,
-      resumelm_is_pro: input.isPro,
-      resumelm_used_server_key: input.resolved.usedServerKey,
-      resumelm_requires_rate_limit: input.resolved.requiresRateLimit,
-      resumelm_environment: input.environment ?? process.env.NODE_ENV ?? "development",
     },
   };
 }

--- a/src/lib/ai/usage-ledger.ts
+++ b/src/lib/ai/usage-ledger.ts
@@ -21,6 +21,31 @@ import { createServiceClient } from "@/utils/supabase/server";
 
 type AIUsageStatus = "succeeded" | "failed" | "rate_limited" | "blocked";
 
+export function getAIErrorCategory(errorCode?: string | null): string | null {
+  if (!errorCode) return null;
+
+  const normalized = errorCode.toLowerCase();
+  if (normalized.includes("quota") || normalized.includes("credit") || normalized.includes("payment")) {
+    return "provider_billing";
+  }
+  if (normalized.includes("api key") || normalized.includes("key not found") || normalized.includes("authentication")) {
+    return "provider_authentication";
+  }
+  if (normalized.includes("rate limit") || normalized.includes("too many requests")) {
+    return "rate_limited";
+  }
+  if (normalized.includes("schema") || normalized.includes("parse") || normalized.includes("tool")) {
+    return "invalid_model_output";
+  }
+  if (normalized.includes("timeout") || normalized.includes("timed out")) {
+    return "timeout";
+  }
+  if (normalized.includes("unavailable") || normalized.includes("network") || normalized.includes("fetch")) {
+    return "provider_unavailable";
+  }
+  return "provider_error";
+}
+
 export class AIUsageError extends Error {
   constructor(
     message: string,
@@ -67,8 +92,7 @@ export async function recordAIUsageStarted(input: {
       route: input.route,
       provider: input.provider,
       model: input.model,
-      is_pro: input.isPro,
-      used_server_key: input.usedServerKey,
+      status: "started",
     },
   });
 
@@ -94,31 +118,59 @@ export async function recordAIUsageFinished(input: {
       total_tokens: input.totalTokens ?? null,
     })
     .eq("id", input.id)
-    .select("user_id, route, provider, model, is_pro, used_server_key, status, input_tokens, output_tokens, total_tokens, error_code")
+    .select("user_id, route, provider, model, status, input_tokens, output_tokens, total_tokens, error_code, created_at")
     .single();
 
   if (error) {
     throw error;
   }
 
+  const durationMs = data.created_at
+    ? Math.max(0, Date.now() - Date.parse(data.created_at))
+    : null;
+  const analyticsProperties = {
+    route: data.route,
+    provider: data.provider,
+    model: data.model,
+    status: data.status,
+    duration_ms: durationMs,
+    input_tokens: data.input_tokens,
+    output_tokens: data.output_tokens,
+    total_tokens: data.total_tokens,
+    error_category: getAIErrorCategory(data.error_code),
+  };
+
   await captureServerAnalyticsEvent({
     distinctId: data.user_id,
     event: input.status === "succeeded"
       ? AnalyticsEvents.AIRequestSucceeded
       : AnalyticsEvents.AIRequestFailed,
-    properties: {
-      route: data.route,
-      provider: data.provider,
-      model: data.model,
-      is_pro: data.is_pro,
-      used_server_key: data.used_server_key,
-      status: data.status,
-      input_tokens: data.input_tokens,
-      output_tokens: data.output_tokens,
-      total_tokens: data.total_tokens,
-      error_code: data.error_code,
-    },
+    properties: analyticsProperties,
   });
+
+  if (input.status === "succeeded") {
+    try {
+      const { count } = await supabase
+        .from("ai_usage_events")
+        .select("id", { count: "exact", head: true })
+        .eq("user_id", data.user_id)
+        .eq("status", "succeeded");
+
+      if (count === 1) {
+        await captureServerAnalyticsEvent({
+          distinctId: data.user_id,
+          event: AnalyticsEvents.FirstAIRequestSucceeded,
+          insertId: `${data.user_id}:${AnalyticsEvents.FirstAIRequestSucceeded}`,
+          properties: analyticsProperties,
+        });
+      }
+    } catch (analyticsError) {
+      console.warn("Unable to determine first successful AI request", {
+        userId: data.user_id,
+        error: analyticsError instanceof Error ? analyticsError.message : "Unknown error",
+      });
+    }
+  }
 }
 
 export function usageFromLanguageModelUsage(usage?: LanguageModelUsage) {

--- a/src/lib/analytics/events.test.ts
+++ b/src/lib/analytics/events.test.ts
@@ -3,19 +3,27 @@ import { describe, it } from "node:test";
 
 import {
   AnalyticsEvents,
+  buildAnalyticsInsertId,
   buildAnalyticsPayload,
   sanitizeAnalyticsProperties,
 } from "./events";
 
 describe("AnalyticsEvents", () => {
   it("defines the operational lifecycle events used by product and billing analytics", () => {
+    assert.equal(AnalyticsEvents.AuthStarted, "auth_started");
+    assert.equal(AnalyticsEvents.AuthSucceeded, "auth_succeeded");
+    assert.equal(AnalyticsEvents.EmailConfirmationCompleted, "email_confirmation_completed");
+    assert.equal(AnalyticsEvents.OAuthCompleted, "oauth_completed");
     assert.equal(AnalyticsEvents.SignupCompleted, "signup_completed");
     assert.equal(AnalyticsEvents.OnboardingCompleted, "onboarding_completed");
     assert.equal(AnalyticsEvents.ProfileCreated, "profile_created");
+    assert.equal(AnalyticsEvents.ProfileCompleted, "profile_completed");
     assert.equal(AnalyticsEvents.ResumeCreated, "resume_created");
+    assert.equal(AnalyticsEvents.FirstResumeSaved, "first_resume_saved");
     assert.equal(AnalyticsEvents.ResumeTailored, "resume_tailored");
     assert.equal(AnalyticsEvents.AIRequestStarted, "ai_request_started");
     assert.equal(AnalyticsEvents.AIRequestSucceeded, "ai_request_succeeded");
+    assert.equal(AnalyticsEvents.FirstAIRequestSucceeded, "first_ai_request_succeeded");
     assert.equal(AnalyticsEvents.AIRequestFailed, "ai_request_failed");
     assert.equal(AnalyticsEvents.CheckoutViewed, "checkout_viewed");
     assert.equal(AnalyticsEvents.CheckoutStarted, "checkout_started");
@@ -28,10 +36,18 @@ describe("AnalyticsEvents", () => {
     assert.equal(AnalyticsEvents.OutboundLinkClicked, "outbound_link_clicked");
     assert.equal(AnalyticsEvents.TrialStarted, "trial_started");
     assert.equal(AnalyticsEvents.FirstInvoicePaid, "first_invoice_paid");
+    assert.equal(AnalyticsEvents.EntitlementActivated, "entitlement_activated");
     assert.equal(AnalyticsEvents.InvoicePaymentFailed, "invoice_payment_failed");
     assert.equal(AnalyticsEvents.SubscriptionCanceled, "subscription_canceled");
     assert.equal(AnalyticsEvents.BillingAlertTriggered, "billing_alert_triggered");
     assert.equal(Object.hasOwn(AnalyticsEvents, "SubscriptionActivated"), false);
+  });
+
+  it("builds stable user-scoped lifecycle insert ids", () => {
+    assert.equal(
+      buildAnalyticsInsertId("user_123", AnalyticsEvents.FirstResumeSaved),
+      "user_123:first_resume_saved",
+    );
   });
 });
 
@@ -90,6 +106,7 @@ describe("buildAnalyticsPayload", () => {
         distinct_id: "user_123",
         event: "resume_created",
         properties: {
+          analytics_user_id: "user_123",
           $geoip_disable: true,
           resume_type: "base",
         },

--- a/src/lib/analytics/events.ts
+++ b/src/lib/analytics/events.ts
@@ -1,11 +1,18 @@
 export const AnalyticsEvents = {
+  AuthStarted: "auth_started",
+  AuthSucceeded: "auth_succeeded",
+  EmailConfirmationCompleted: "email_confirmation_completed",
+  OAuthCompleted: "oauth_completed",
   SignupCompleted: "signup_completed",
   OnboardingCompleted: "onboarding_completed",
   ProfileCreated: "profile_created",
+  ProfileCompleted: "profile_completed",
   ResumeCreated: "resume_created",
+  FirstResumeSaved: "first_resume_saved",
   ResumeTailored: "resume_tailored",
   AIRequestStarted: "ai_request_started",
   AIRequestSucceeded: "ai_request_succeeded",
+  FirstAIRequestSucceeded: "first_ai_request_succeeded",
   AIRequestFailed: "ai_request_failed",
   CheckoutViewed: "checkout_viewed",
   CheckoutStarted: "checkout_started",
@@ -18,6 +25,7 @@ export const AnalyticsEvents = {
   OutboundLinkClicked: "outbound_link_clicked",
   TrialStarted: "trial_started",
   FirstInvoicePaid: "first_invoice_paid",
+  EntitlementActivated: "entitlement_activated",
   InvoicePaymentFailed: "invoice_payment_failed",
   SubscriptionCanceled: "subscription_canceled",
   BillingAlertTriggered: "billing_alert_triggered",
@@ -70,8 +78,13 @@ export function buildAnalyticsPayload(input: {
     event: input.event,
     properties: {
       ...sanitizeAnalyticsProperties(input.properties),
+      analytics_user_id: input.distinctId,
       $geoip_disable: true,
       ...(input.insertId ? { $insert_id: input.insertId } : {}),
     },
   };
+}
+
+export function buildAnalyticsInsertId(userId: string, event: AnalyticsEventName) {
+  return `${userId}:${event}`;
 }

--- a/src/utils/actions/profiles/actions.ts
+++ b/src/utils/actions/profiles/actions.ts
@@ -13,6 +13,31 @@ function isProfileComplete(profile: Partial<Profile> | null | undefined) {
   return Boolean(profile?.first_name && profile?.last_name && profile?.email);
 }
 
+async function captureProfileCompletionIfNeeded(input: {
+  supabase: Awaited<ReturnType<typeof createClient>>;
+  userId: string;
+  previousProfile: Partial<Profile> | null | undefined;
+  profile: Partial<Profile> | null | undefined;
+}) {
+  if (isProfileComplete(input.previousProfile) || !isProfileComplete(input.profile)) {
+    return;
+  }
+
+  const properties = await getSubscriptionAnalyticsProperties(input.supabase, input.userId);
+  await captureServerAnalyticsEvent({
+    distinctId: input.userId,
+    event: AnalyticsEvents.OnboardingCompleted,
+    insertId: `${input.userId}:${AnalyticsEvents.OnboardingCompleted}`,
+    properties,
+  });
+  await captureServerAnalyticsEvent({
+    distinctId: input.userId,
+    event: AnalyticsEvents.ProfileCompleted,
+    insertId: `${input.userId}:${AnalyticsEvents.ProfileCompleted}`,
+    properties,
+  });
+}
+
 export async function updateProfile(data: Partial<Profile>): Promise<Profile> {
   const supabase = await createClient();
   const { data: { user }, error: userError } = await supabase.auth.getUser();
@@ -38,13 +63,12 @@ export async function updateProfile(data: Partial<Profile>): Promise<Profile> {
     throw new Error(`Failed to update profile: ${error.message}`);
   }
 
-  if (!isProfileComplete(currentProfile) && isProfileComplete(profile)) {
-    await captureServerAnalyticsEvent({
-      distinctId: user.id,
-      event: AnalyticsEvents.OnboardingCompleted,
-      properties: await getSubscriptionAnalyticsProperties(supabase, user.id),
-    });
-  }
+  await captureProfileCompletionIfNeeded({
+    supabase,
+    userId: user.id,
+    previousProfile: currentProfile,
+    profile,
+  });
 
   // Revalidate all routes that might display profile data
   revalidatePath('/', 'layout');
@@ -122,13 +146,12 @@ export async function importResume(data: Partial<Profile>): Promise<Profile> {
     throw new Error(`Failed to update profile: ${error.message}`);
   }
 
-  if (!isProfileComplete(currentProfile) && isProfileComplete(profile)) {
-    await captureServerAnalyticsEvent({
-      distinctId: user.id,
-      event: AnalyticsEvents.OnboardingCompleted,
-      properties: await getSubscriptionAnalyticsProperties(supabase, user.id),
-    });
-  }
+  await captureProfileCompletionIfNeeded({
+    supabase,
+    userId: user.id,
+    previousProfile: currentProfile,
+    profile,
+  });
 
   // Revalidate all routes that might display profile data
   revalidatePath('/', 'layout');

--- a/src/utils/actions/resumes/actions.ts
+++ b/src/utils/actions/resumes/actions.ts
@@ -257,6 +257,12 @@ export async function createBaseResume(
 
   await assertResumeQuota(supabase, user.id, 'base');
 
+  const { count: existingResumeCount } = await supabase
+    .from('resumes')
+    .select('id', { count: 'exact', head: true })
+    .eq('user_id', user.id);
+  const isFirstResume = existingResumeCount === 0;
+
   let profile = null;
   if (importOption !== 'fresh') {
     const { data, error: profileError } = await supabase
@@ -360,12 +366,25 @@ export async function createBaseResume(
   await captureServerAnalyticsEvent({
     distinctId: user.id,
     event: AnalyticsEvents.ResumeCreated,
+    insertId: `${user.id}:${resume.id}:${AnalyticsEvents.ResumeCreated}`,
     properties: {
       ...(await getSubscriptionAnalyticsProperties(supabase, user.id)),
       resume_type: "base",
       has_job: false,
     },
   });
+
+  if (isFirstResume) {
+    await captureServerAnalyticsEvent({
+      distinctId: user.id,
+      event: AnalyticsEvents.FirstResumeSaved,
+      insertId: `${user.id}:${AnalyticsEvents.FirstResumeSaved}`,
+      properties: {
+        resume_type: "base",
+        import_option: importOption,
+      },
+    });
+  }
 
   return resume;
 }


### PR DESCRIPTION
## Summary

- Add stable-user lifecycle events for auth, email confirmation, OAuth completion, profile completion, first resume, first successful AI request, checkout failures, first paid invoice, and entitlement activation.
- Ensure authenticated browser pageviews identify the Supabase user UUID before capture and server events expose the same stable analytics_user_id.
- Disable PostHog AI input/output capture and reduce AI event payloads to route, provider, model, latency, status, bounded error category, and token counts.
- Make Stripe checkout/webhook initialization lazy so production builds do not require secrets at build time.
- Gate the checkout success state on Stripe session ownership and webhook-backed entitlement state.

## Verification

- `pnpm test` — 77 passing
- `pnpm typecheck` — passing
- `pnpm lint` — passing
- `pnpm build` — passing; existing OpenTelemetry critical-dependency warning remains
- `git diff --check` — passing

## Deployment

Merging to `main` triggers the existing Docker image publish workflow for the production image.