### PR TITLE
fix: make entitlement activation transition-safe

### DIFF
--- a/src/app/api/webhooks/stripe/route.ts
+++ b/src/app/api/webhooks/stripe/route.ts
@@ -7,6 +7,7 @@ import { createServiceClient } from '@/utils/supabase/server'
 import { reportBillingAlert } from '@/lib/billing/alerts'
 import { AnalyticsEvents } from '@/lib/analytics/events'
 import { captureServerAnalyticsEvent } from '@/lib/analytics/server'
+import { shouldCaptureEntitlementActivation } from '@/lib/billing/entitlement-activation'
 import {
   normalizeAnalyticsAnonymousId,
   UTM_PARAMETER_NAMES,
@@ -266,6 +267,16 @@ async function handleSubscriptionChange(
       subscriptionId,
     });
 
+    const { data: previousSubscription, error: previousSubscriptionError } = await supabase
+      .from('subscriptions')
+      .select('subscription_plan, subscription_status, current_period_end, trial_end')
+      .eq('stripe_subscription_id', subscriptionId)
+      .maybeSingle();
+
+    if (previousSubscriptionError) {
+      throw previousSubscriptionError;
+    }
+
     // Update subscription in database
     const subscriptionData = await manageSubscriptionStatusChange(
       subscriptionId,
@@ -290,15 +301,33 @@ async function handleSubscriptionChange(
 
     if (
       subscriptionData.user_id &&
+      subscriptionData.stripe_subscription_id === subscriptionId &&
       subscriptionData.subscription_plan === 'pro' &&
-      subscriptionData.subscription_status === 'active'
+      subscriptionData.subscription_status === 'active' &&
+      shouldCaptureEntitlementActivation(previousSubscription, subscriptionData)
     ) {
-      await captureServerAnalyticsEvent({
-        distinctId: subscriptionData.user_id,
-        event: AnalyticsEvents.EntitlementActivated,
-        insertId: `${subscriptionId}:${AnalyticsEvents.EntitlementActivated}`,
-        properties: getSubscriptionEventProperties(subscriptionData, 'entitlement.activated'),
-      });
+      const { error: activationClaimError } = await supabase
+        .from('stripe_entitlement_activations')
+        .insert({
+          stripe_subscription_id: subscriptionId,
+          user_id: subscriptionData.user_id,
+        });
+
+      const isDuplicateActivation =
+        (activationClaimError as { code?: string } | null)?.code === '23505';
+
+      if (activationClaimError && !isDuplicateActivation) {
+        throw activationClaimError;
+      }
+
+      if (!activationClaimError) {
+        await captureServerAnalyticsEvent({
+          distinctId: subscriptionData.user_id,
+          event: AnalyticsEvents.EntitlementActivated,
+          insertId: `${subscriptionId}:${AnalyticsEvents.EntitlementActivated}`,
+          properties: getSubscriptionEventProperties(subscriptionData, 'entitlement.activated'),
+        });
+      }
     }
     
     console.log('✨ Final Subscription State:', {

--- a/src/lib/billing/entitlement-activation.test.ts
+++ b/src/lib/billing/entitlement-activation.test.ts
@@ -1,0 +1,58 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+
+import { shouldCaptureEntitlementActivation } from "./entitlement-activation";
+
+const now = new Date("2026-08-29T12:00:00Z");
+const currentActive = {
+  subscription_plan: "pro",
+  subscription_status: "active",
+  current_period_end: "2026-09-29T12:00:00Z",
+  trial_end: null,
+};
+
+describe("entitlement activation transitions", () => {
+  it("captures a new active entitlement", () => {
+    assert.equal(
+      shouldCaptureEntitlementActivation(null, currentActive, now),
+      true,
+    );
+  });
+
+  it("does not recapture an already-active entitlement", () => {
+    assert.equal(
+      shouldCaptureEntitlementActivation(currentActive, currentActive, now),
+      false,
+    );
+  });
+
+  it("captures a transition from free to active", () => {
+    assert.equal(
+      shouldCaptureEntitlementActivation(
+        {
+          subscription_plan: "free",
+          subscription_status: null,
+          current_period_end: null,
+          trial_end: null,
+        },
+        currentActive,
+        now,
+      ),
+      true,
+    );
+  });
+
+  it("does not treat a still-entitled past-due recovery as a new activation", () => {
+    assert.equal(
+      shouldCaptureEntitlementActivation(
+        {
+          ...currentActive,
+          subscription_status: "past_due",
+        },
+        currentActive,
+        now,
+      ),
+      false,
+    );
+  });
+});

--- a/src/lib/billing/entitlement-activation.ts
+++ b/src/lib/billing/entitlement-activation.ts
@@ -1,0 +1,19 @@
+import { getSubscriptionAccessState, type SubscriptionSnapshot } from "@/lib/subscription-access";
+
+type EntitlementSnapshot = Pick<
+  SubscriptionSnapshot,
+  "subscription_plan" | "subscription_status" | "current_period_end" | "trial_end"
+>;
+
+export function shouldCaptureEntitlementActivation(
+  previous: EntitlementSnapshot | null | undefined,
+  current: EntitlementSnapshot,
+  now: Date = new Date(),
+): boolean {
+  const wasEntitled = previous
+    ? getSubscriptionAccessState(previous, now).hasProAccess
+    : false;
+  const isEntitled = getSubscriptionAccessState(current, now).hasProAccess;
+
+  return !wasEntitled && isEntitled;
+}

--- a/src/lib/billing/reconciliation.ts
+++ b/src/lib/billing/reconciliation.ts
@@ -36,7 +36,11 @@ export interface ReconciliationMismatch {
   expectedStatus: "active" | "past_due" | "canceled";
 }
 
-function expectedAppState(input: StripeReconciliationSnapshot, proPriceId: string) {
+function expectedAppState(
+  input: StripeReconciliationSnapshot,
+  proPriceId: string,
+  now: Date,
+) {
   const isKnownProPrice = input.priceId === proPriceId;
   const isActiveLike = input.status === "active" || input.status === "trialing";
   const isPastDue = input.status === "past_due";
@@ -51,14 +55,17 @@ function expectedAppState(input: StripeReconciliationSnapshot, proPriceId: strin
   return {
     expectedPlan,
     expectedStatus,
-    expectedState: getBillingState({
-      plan: expectedPlan,
-      status: expectedStatus,
-      stripeStatus: input.status,
-      currentPeriodEnd: input.currentPeriodEnd,
-      trialEnd: input.trialEnd,
-      cancelAtPeriodEnd: input.cancelAtPeriodEnd,
-    }),
+    expectedState: getBillingState(
+      {
+        plan: expectedPlan,
+        status: expectedStatus,
+        stripeStatus: input.status,
+        currentPeriodEnd: input.currentPeriodEnd,
+        trialEnd: input.trialEnd,
+        cancelAtPeriodEnd: input.cancelAtPeriodEnd,
+      },
+      now,
+    ),
   } as const;
 }
 
@@ -69,7 +76,7 @@ export function compareStripeAndSupabaseState(input: {
   now?: Date;
 }): ReconciliationMismatch | null {
   const now = input.now ?? new Date();
-  const expected = expectedAppState(input.stripe, input.proPriceId);
+  const expected = expectedAppState(input.stripe, input.proPriceId, now);
 
   // Historical canceled subscriptions do not need a user mapping. Current or
   // recoverable entitlements do, because missing mappings can strand paid access.
@@ -126,5 +133,5 @@ export function compareStripeAndSupabaseState(input: {
 }
 
 export function getExpectedStripeState(input: StripeReconciliationSnapshot, proPriceId: string) {
-  return expectedAppState(input, proPriceId);
+  return expectedAppState(input, proPriceId, new Date());
 }

--- a/supabase/migrations/20260830001920_entitlement_activation_claims.sql
+++ b/supabase/migrations/20260830001920_entitlement_activation_claims.sql
@@ -1,0 +1,12 @@
+CREATE TABLE IF NOT EXISTS public.stripe_entitlement_activations (
+  stripe_subscription_id text PRIMARY KEY,
+  user_id uuid NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+  first_activated_at timestamp with time zone NOT NULL DEFAULT timezone('utc'::text, now())
+);
+
+ALTER TABLE public.stripe_entitlement_activations ENABLE ROW LEVEL SECURITY;
+REVOKE ALL ON TABLE public.stripe_entitlement_activations FROM anon, authenticated;
+GRANT ALL ON TABLE public.stripe_entitlement_activations TO service_role;
+
+COMMENT ON TABLE public.stripe_entitlement_activations IS
+  'One service-owned entitlement activation claim per Stripe subscription lifecycle.';

--- a/supabase/migrations/20260830002001_add_entitlement_activation_user_index.sql
+++ b/supabase/migrations/20260830002001_add_entitlement_activation_user_index.sql
@@ -1,0 +1,2 @@
+CREATE INDEX IF NOT EXISTS stripe_entitlement_activations_user_id_idx
+  ON public.stripe_entitlement_activations (user_id);


### PR DESCRIPTION
Fix billing reconciliation clock injection and make Stripe entitlement activation transition-safe. Adds atomic service-owned activation claims, regression tests, and indexed/RLS-protected Supabase migrations. Local verification: 109 tests passed, lint passed, typecheck passed, trust checks passed, production build passed.