### PR TITLE
Improve AI latency and production observability

### DIFF
--- a/src/app/api/chat/route.ts
+++ b/src/app/api/chat/route.ts
@@ -159,6 +159,7 @@ export async function POST(req: Request) {
           usageEventId,
           status: 'failed',
           errorCode: error instanceof Error ? error.message : 'stream_error',
+          error,
         });
       },
     });

--- a/src/app/api/webhooks/stripe/route.ts
+++ b/src/app/api/webhooks/stripe/route.ts
@@ -7,6 +7,7 @@ import { createServiceClient } from '@/utils/supabase/server'
 import { reportBillingAlert } from '@/lib/billing/alerts'
 import { AnalyticsEvents } from '@/lib/analytics/events'
 import { captureServerAnalyticsEvent } from '@/lib/analytics/server'
+import { shouldCaptureEntitlementActivation } from '@/lib/billing/entitlement-activation'
 import {
   normalizeAnalyticsAnonymousId,
   UTM_PARAMETER_NAMES,
@@ -266,6 +267,16 @@ async function handleSubscriptionChange(
       subscriptionId,
     });
 
+    const { data: previousSubscription, error: previousSubscriptionError } = await supabase
+      .from('subscriptions')
+      .select('subscription_plan, subscription_status, current_period_end, trial_end')
+      .eq('stripe_subscription_id', subscriptionId)
+      .maybeSingle();
+
+    if (previousSubscriptionError) {
+      throw previousSubscriptionError;
+    }
+
     // Update subscription in database
     const subscriptionData = await manageSubscriptionStatusChange(
       subscriptionId,
@@ -290,15 +301,33 @@ async function handleSubscriptionChange(
 
     if (
       subscriptionData.user_id &&
+      subscriptionData.stripe_subscription_id === subscriptionId &&
       subscriptionData.subscription_plan === 'pro' &&
-      subscriptionData.subscription_status === 'active'
+      subscriptionData.subscription_status === 'active' &&
+      shouldCaptureEntitlementActivation(previousSubscription, subscriptionData)
     ) {
-      await captureServerAnalyticsEvent({
-        distinctId: subscriptionData.user_id,
-        event: AnalyticsEvents.EntitlementActivated,
-        insertId: `${subscriptionId}:${AnalyticsEvents.EntitlementActivated}`,
-        properties: getSubscriptionEventProperties(subscriptionData, 'entitlement.activated'),
-      });
+      const { error: activationClaimError } = await supabase
+        .from('stripe_entitlement_activations')
+        .insert({
+          stripe_subscription_id: subscriptionId,
+          user_id: subscriptionData.user_id,
+        });
+
+      const isDuplicateActivation =
+        (activationClaimError as { code?: string } | null)?.code === '23505';
+
+      if (activationClaimError && !isDuplicateActivation) {
+        throw activationClaimError;
+      }
+
+      if (!activationClaimError) {
+        await captureServerAnalyticsEvent({
+          distinctId: subscriptionData.user_id,
+          event: AnalyticsEvents.EntitlementActivated,
+          insertId: `${subscriptionId}:${AnalyticsEvents.EntitlementActivated}`,
+          properties: getSubscriptionEventProperties(subscriptionData, 'entitlement.activated'),
+        });
+      }
     }
     
     console.log('✨ Final Subscription State:', {

--- a/src/app/error.tsx
+++ b/src/app/error.tsx
@@ -1,5 +1,16 @@
 'use client'
 
-export default function Error() {
+import { useEffect } from 'react';
+import posthog from 'posthog-js';
+
+export default function Error({ error }: { error: Error & { digest?: string } }) {
+  useEffect(() => {
+    posthog.captureException(error, {
+      exception_source: 'next_error_boundary',
+      error_digest: error.digest ?? null,
+      pathname: window.location.pathname,
+    });
+  }, [error]);
+
   return <p>Sorry, something went wrong</p>
 }

--- a/src/components/analytics/posthog-provider.tsx
+++ b/src/components/analytics/posthog-provider.tsx
@@ -34,6 +34,11 @@ export function PostHogProvider({
       defaults: '2026-01-30',
       capture_pageview: false,
       capture_pageleave: true,
+      capture_exceptions: {
+        capture_unhandled_errors: true,
+        capture_unhandled_rejections: true,
+        capture_console_errors: false,
+      },
     });
 
     hasInitialized = true;

--- a/src/components/resume/editor/panels/editor-panel.tsx
+++ b/src/components/resume/editor/panels/editor-panel.tsx
@@ -45,7 +45,7 @@ export function EditorPanel({
   const posthog = usePostHog();
 
   return (
-    <div className="flex flex-col sm:mr-4 relative h-full max-h-full  ">
+    <div className="flex flex-col sm:mr-4 relative h-full max-h-full" data-analytics-id="resume-editor-panel">
       <div className="flex-1 flex flex-col overflow-scroll">
         <ScrollArea className="flex-1 sm:pr-2" ref={scrollAreaRef}>
           <div className="relative pb-12">

--- a/src/components/resume/editor/panels/resume-score-panel.tsx
+++ b/src/components/resume/editor/panels/resume-score-panel.tsx
@@ -287,6 +287,7 @@ export default function ResumeScorePanel({ resume, job }: ResumeScorePanelProps)
               <Button
                 onClick={handleRecalculate}
                 disabled={isCalculating}
+                data-analytics-id="editor-score-generate"
                 className="w-full sm:w-auto"
               >
                 <RefreshCw 
@@ -315,6 +316,7 @@ export default function ResumeScorePanel({ resume, job }: ResumeScorePanelProps)
         <Button
           onClick={handleRecalculate}
           disabled={isCalculating}
+          data-analytics-id="editor-score-recalculate"
           variant="outline"
           size="sm"
         >

--- a/src/components/resume/editor/preview/resume-context-menu.tsx
+++ b/src/components/resume/editor/preview/resume-context-menu.tsx
@@ -187,7 +187,11 @@ export function ResumeContextMenu({ children, resume }: ResumeContextMenuProps) 
 
   return (
     <ContextMenu>
-      <ContextMenuTrigger className="w-full h-full">
+      <ContextMenuTrigger
+        className="w-full h-full"
+        data-analytics-id="resume-preview"
+        aria-label="Resume preview"
+      >
         {children}
       </ContextMenuTrigger>
       <ContextMenuContent className="w-64">

--- a/src/instrumentation.ts
+++ b/src/instrumentation.ts
@@ -1,5 +1,45 @@
+import type { Instrumentation } from 'next';
+
+import { AnalyticsEvents } from '@/lib/analytics/events';
+import { captureServerAnalyticsEvent } from '@/lib/analytics/server';
+
 export async function register() {
   if (process.env.NEXT_RUNTIME === "nodejs") {
     await import("./instrumentation.node");
   }
 }
+
+function truncate(value: string | undefined, maxLength: number) {
+  return value?.slice(0, maxLength) ?? null;
+}
+
+export const onRequestError: Instrumentation.onRequestError = async (
+  error,
+  request,
+  context,
+) => {
+  const capturedError = error instanceof Error ? error : new Error('Unknown request error');
+  const digest =
+    typeof (error as { digest?: unknown })?.digest === 'string'
+      ? (error as { digest: string }).digest
+      : null;
+
+  await captureServerAnalyticsEvent({
+    distinctId: 'resumelm-server',
+    event: AnalyticsEvents.ExceptionCaptured,
+    identitySource: 'server',
+    properties: {
+      $exception_type: capturedError.name,
+      $exception_message: truncate(capturedError.message, 1000),
+      $exception_stack_trace_raw: truncate(capturedError.stack, 6000),
+      $exception_handled: false,
+      $exception_digest: digest,
+      exception_source: 'next_on_request_error',
+      route_path: context.routePath,
+      route_type: context.routeType,
+      request_method: request.method,
+      pathname: request.path.split('?')[0].slice(0, 300),
+      runtime: process.env.NEXT_RUNTIME ?? 'nodejs',
+    },
+  });
+};

--- a/src/lib/ai/posthog-telemetry.test.ts
+++ b/src/lib/ai/posthog-telemetry.test.ts
@@ -3,7 +3,7 @@ import { afterEach, describe, it } from "node:test";
 
 import type { ResolvedAIRequest } from "./access-control";
 import { buildPostHogAITelemetry } from "./posthog-telemetry";
-import { getAIErrorCategory } from "./usage-ledger";
+import { getAIErrorCategory, getAIRequestFailureProperties } from "./usage-ledger";
 
 const ORIGINAL_ENV = {
   NEXT_PUBLIC_POSTHOG_KEY: process.env.NEXT_PUBLIC_POSTHOG_KEY,
@@ -128,5 +128,21 @@ describe("getAIErrorCategory", () => {
     assert.equal(getAIErrorCategory("No object generated: response did not match schema"), "invalid_model_output");
     assert.equal(getAIErrorCategory("Unexpected provider failure"), "provider_error");
     assert.equal(getAIErrorCategory(undefined), null);
+  });
+});
+
+describe("getAIRequestFailureProperties", () => {
+  it("emits bounded structured fields without the provider's raw error", () => {
+    assert.deepEqual(
+      getAIRequestFailureProperties({
+        errorCode: "You exceeded your current quota",
+      }),
+      {
+        error_code: "provider_billing",
+        error_category: "provider_billing",
+        error_status_code: null,
+        error_retryable: null,
+      },
+    );
   });
 });

--- a/src/lib/ai/usage-ledger.ts
+++ b/src/lib/ai/usage-ledger.ts
@@ -8,6 +8,7 @@ import {
   AIProviderError,
   MODEL_UNAVAILABLE_MESSAGE,
   assertProviderCircuitClosed,
+  classifyAIError,
 } from "@/lib/ai/reliability";
 import { getDefaultModel } from "@/lib/ai-models";
 import { buildPostHogAITelemetry } from "@/lib/ai/posthog-telemetry";
@@ -44,6 +45,22 @@ export function getAIErrorCategory(errorCode?: string | null): string | null {
     return "provider_unavailable";
   }
   return "provider_error";
+}
+
+export function getAIRequestFailureProperties(input: {
+  errorCode?: string | null;
+  error?: unknown;
+}) {
+  const classification = input.error ? classifyAIError(input.error) : null;
+  const category =
+    classification?.kind ?? getAIErrorCategory(input.errorCode) ?? "provider_error";
+
+  return {
+    error_code: category,
+    error_category: category,
+    error_status_code: classification?.statusCode ?? null,
+    error_retryable: classification?.retryable ?? null,
+  } as const;
 }
 
 export class AIUsageError extends Error {
@@ -85,7 +102,7 @@ export async function recordAIUsageStarted(input: {
     throw error;
   }
 
-  await captureServerAnalyticsEvent({
+  void captureServerAnalyticsEvent({
     distinctId: input.userId,
     event: AnalyticsEvents.AIRequestStarted,
     properties: {
@@ -103,6 +120,7 @@ export async function recordAIUsageFinished(input: {
   id: string;
   status: AIUsageStatus;
   errorCode?: string;
+  error?: unknown;
   inputTokens?: number;
   outputTokens?: number;
   totalTokens?: number;
@@ -137,10 +155,15 @@ export async function recordAIUsageFinished(input: {
     input_tokens: data.input_tokens,
     output_tokens: data.output_tokens,
     total_tokens: data.total_tokens,
-    error_category: getAIErrorCategory(data.error_code),
+    ...(input.status === "succeeded"
+      ? {}
+      : getAIRequestFailureProperties({
+          errorCode: data.error_code,
+          error: input.error,
+        })),
   };
 
-  await captureServerAnalyticsEvent({
+  const analyticsCapture = captureServerAnalyticsEvent({
     distinctId: data.user_id,
     event: input.status === "succeeded"
       ? AnalyticsEvents.AIRequestSucceeded
@@ -148,28 +171,41 @@ export async function recordAIUsageFinished(input: {
     properties: analyticsProperties,
   });
 
+  // Successful requests should not wait for analytics delivery. Failure
+  // telemetry stays awaited because it is the diagnostic signal for the user
+  // experience that just failed.
   if (input.status === "succeeded") {
-    try {
-      const { count } = await supabase
-        .from("ai_usage_events")
-        .select("id", { count: "exact", head: true })
-        .eq("user_id", data.user_id)
-        .eq("status", "succeeded");
+    void analyticsCapture;
+  } else {
+    await analyticsCapture;
+  }
 
-      if (count === 1) {
-        await captureServerAnalyticsEvent({
-          distinctId: data.user_id,
-          event: AnalyticsEvents.FirstAIRequestSucceeded,
-          insertId: `${data.user_id}:${AnalyticsEvents.FirstAIRequestSucceeded}`,
-          properties: analyticsProperties,
+  if (input.status === "succeeded") {
+    // This secondary milestone must never add another database round trip to
+    // the user's AI response. It is best-effort analytics, not access control.
+    void (async () => {
+      try {
+        const { count } = await supabase
+          .from("ai_usage_events")
+          .select("id", { count: "exact", head: true })
+          .eq("user_id", data.user_id)
+          .eq("status", "succeeded");
+
+        if (count === 1) {
+          await captureServerAnalyticsEvent({
+            distinctId: data.user_id,
+            event: AnalyticsEvents.FirstAIRequestSucceeded,
+            insertId: `${data.user_id}:${AnalyticsEvents.FirstAIRequestSucceeded}`,
+            properties: analyticsProperties,
+          });
+        }
+      } catch (analyticsError) {
+        console.warn("Unable to determine first successful AI request", {
+          userId: data.user_id,
+          error: analyticsError instanceof Error ? analyticsError.message : "Unknown error",
         });
       }
-    } catch (analyticsError) {
-      console.warn("Unable to determine first successful AI request", {
-        userId: data.user_id,
-        error: analyticsError instanceof Error ? analyticsError.message : "Unknown error",
-      });
-    }
+    })();
   }
 }
 
@@ -190,11 +226,13 @@ export async function finishAIUsageRequest(input: {
   status: AIUsageStatus;
   usage?: LanguageModelUsage;
   errorCode?: string;
+  error?: unknown;
 }) {
   await recordAIUsageFinished({
     id: input.usageEventId,
     status: input.status,
     errorCode: input.errorCode,
+    error: input.error,
     ...usageFromLanguageModelUsage(input.usage),
   });
 }
@@ -234,6 +272,7 @@ export async function startAIUsageRequest(input: {
       id: usageEventId,
       status: "blocked",
       errorCode: error instanceof Error ? error.message : "access_denied",
+      error,
     });
 
     throw new AIUsageError(
@@ -267,6 +306,7 @@ export async function startAIUsageRequest(input: {
       id: usageEventId,
       status: "blocked",
       errorCode: error instanceof Error ? error.message : "provider_circuit_open",
+      error,
     });
 
     throw new AIUsageError(
@@ -294,6 +334,7 @@ export async function startAIUsageRequest(input: {
         id: usageEventId,
         status: "rate_limited",
         errorCode: error instanceof Error ? error.message : "rate_limit_exceeded",
+        error,
       });
 
       throw new AIUsageError(

--- a/src/lib/analytics/events.test.ts
+++ b/src/lib/analytics/events.test.ts
@@ -40,6 +40,7 @@ describe("AnalyticsEvents", () => {
     assert.equal(AnalyticsEvents.InvoicePaymentFailed, "invoice_payment_failed");
     assert.equal(AnalyticsEvents.SubscriptionCanceled, "subscription_canceled");
     assert.equal(AnalyticsEvents.BillingAlertTriggered, "billing_alert_triggered");
+    assert.equal(AnalyticsEvents.ExceptionCaptured, "$exception");
     assert.equal(Object.hasOwn(AnalyticsEvents, "SubscriptionActivated"), false);
   });
 

--- a/src/lib/analytics/events.ts
+++ b/src/lib/analytics/events.ts
@@ -29,6 +29,7 @@ export const AnalyticsEvents = {
   InvoicePaymentFailed: "invoice_payment_failed",
   SubscriptionCanceled: "subscription_canceled",
   BillingAlertTriggered: "billing_alert_triggered",
+  ExceptionCaptured: "$exception",
 } as const;
 
 export type AnalyticsEventName =

--- a/src/lib/analytics/server.ts
+++ b/src/lib/analytics/server.ts
@@ -50,6 +50,7 @@ export async function captureServerAnalyticsEvent(input: {
   insertId?: string;
   properties?: AnalyticsProperties;
   context?: Partial<AnalyticsAttributionContext>;
+  identitySource?: string;
 }) {
   const distinctId = input.distinctId?.trim();
   if (!posthogKey || !distinctId) return;
@@ -80,7 +81,7 @@ export async function captureServerAnalyticsEvent(input: {
             ...getAnalyticsContextProperties(context),
             analytics_user_id: distinctId,
             capture_source: "server",
-            identity_source: "supabase_user_id",
+            identity_source: input.identitySource ?? "supabase_user_id",
           },
         })
       ),

--- a/src/lib/billing/entitlement-activation.test.ts
+++ b/src/lib/billing/entitlement-activation.test.ts
@@ -1,0 +1,58 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+
+import { shouldCaptureEntitlementActivation } from "./entitlement-activation";
+
+const now = new Date("2026-08-29T12:00:00Z");
+const currentActive = {
+  subscription_plan: "pro",
+  subscription_status: "active",
+  current_period_end: "2026-09-29T12:00:00Z",
+  trial_end: null,
+};
+
+describe("entitlement activation transitions", () => {
+  it("captures a new active entitlement", () => {
+    assert.equal(
+      shouldCaptureEntitlementActivation(null, currentActive, now),
+      true,
+    );
+  });
+
+  it("does not recapture an already-active entitlement", () => {
+    assert.equal(
+      shouldCaptureEntitlementActivation(currentActive, currentActive, now),
+      false,
+    );
+  });
+
+  it("captures a transition from free to active", () => {
+    assert.equal(
+      shouldCaptureEntitlementActivation(
+        {
+          subscription_plan: "free",
+          subscription_status: null,
+          current_period_end: null,
+          trial_end: null,
+        },
+        currentActive,
+        now,
+      ),
+      true,
+    );
+  });
+
+  it("does not treat a still-entitled past-due recovery as a new activation", () => {
+    assert.equal(
+      shouldCaptureEntitlementActivation(
+        {
+          ...currentActive,
+          subscription_status: "past_due",
+        },
+        currentActive,
+        now,
+      ),
+      false,
+    );
+  });
+});

--- a/src/lib/billing/entitlement-activation.ts
+++ b/src/lib/billing/entitlement-activation.ts
@@ -1,0 +1,19 @@
+import { getSubscriptionAccessState, type SubscriptionSnapshot } from "@/lib/subscription-access";
+
+type EntitlementSnapshot = Pick<
+  SubscriptionSnapshot,
+  "subscription_plan" | "subscription_status" | "current_period_end" | "trial_end"
+>;
+
+export function shouldCaptureEntitlementActivation(
+  previous: EntitlementSnapshot | null | undefined,
+  current: EntitlementSnapshot,
+  now: Date = new Date(),
+): boolean {
+  const wasEntitled = previous
+    ? getSubscriptionAccessState(previous, now).hasProAccess
+    : false;
+  const isEntitled = getSubscriptionAccessState(current, now).hasProAccess;
+
+  return !wasEntitled && isEntitled;
+}

--- a/src/lib/billing/reconciliation.ts
+++ b/src/lib/billing/reconciliation.ts
@@ -36,7 +36,11 @@ export interface ReconciliationMismatch {
   expectedStatus: "active" | "past_due" | "canceled";
 }
 
-function expectedAppState(input: StripeReconciliationSnapshot, proPriceId: string) {
+function expectedAppState(
+  input: StripeReconciliationSnapshot,
+  proPriceId: string,
+  now: Date,
+) {
   const isKnownProPrice = input.priceId === proPriceId;
   const isActiveLike = input.status === "active" || input.status === "trialing";
   const isPastDue = input.status === "past_due";
@@ -51,14 +55,17 @@ function expectedAppState(input: StripeReconciliationSnapshot, proPriceId: strin
   return {
     expectedPlan,
     expectedStatus,
-    expectedState: getBillingState({
-      plan: expectedPlan,
-      status: expectedStatus,
-      stripeStatus: input.status,
-      currentPeriodEnd: input.currentPeriodEnd,
-      trialEnd: input.trialEnd,
-      cancelAtPeriodEnd: input.cancelAtPeriodEnd,
-    }),
+    expectedState: getBillingState(
+      {
+        plan: expectedPlan,
+        status: expectedStatus,
+        stripeStatus: input.status,
+        currentPeriodEnd: input.currentPeriodEnd,
+        trialEnd: input.trialEnd,
+        cancelAtPeriodEnd: input.cancelAtPeriodEnd,
+      },
+      now,
+    ),
   } as const;
 }
 
@@ -69,7 +76,7 @@ export function compareStripeAndSupabaseState(input: {
   now?: Date;
 }): ReconciliationMismatch | null {
   const now = input.now ?? new Date();
-  const expected = expectedAppState(input.stripe, input.proPriceId);
+  const expected = expectedAppState(input.stripe, input.proPriceId, now);
 
   // Historical canceled subscriptions do not need a user mapping. Current or
   // recoverable entitlements do, because missing mappings can strand paid access.
@@ -126,5 +133,5 @@ export function compareStripeAndSupabaseState(input: {
 }
 
 export function getExpectedStripeState(input: StripeReconciliationSnapshot, proPriceId: string) {
-  return expectedAppState(input, proPriceId);
+  return expectedAppState(input, proPriceId, new Date());
 }

--- a/src/utils/actions/cover-letter/actions.ts
+++ b/src/utils/actions/cover-letter/actions.ts
@@ -128,6 +128,7 @@ export async function generate(input: string, config?: AIConfig) {
            usageEventId,
            status: 'failed',
            errorCode: error instanceof Error ? error.message : 'stream_error',
+           error,
          });
        },
  

--- a/src/utils/actions/jobs/ai.ts
+++ b/src/utils/actions/jobs/ai.ts
@@ -40,6 +40,7 @@ async function runTrackedAIRequest<T extends { usage?: LanguageModelUsage }>(
       usageEventId,
       status: 'failed',
       errorCode: error instanceof Error ? error.message : 'ai_request_failed',
+      error,
     });
     throw error;
   }
@@ -53,6 +54,22 @@ export async function tailorResumeToJob(
   const { plan, id } = await getSubscriptionPlan(true);
   const isPro = plan === 'pro';
   const selectedConfig = withTaskModel({ task: "jobTailoring", isPro, config });
+  const resumeForTailoring = {
+    target_role: resume.target_role,
+    work_experience: resume.work_experience,
+    education: resume.education,
+    skills: resume.skills,
+    projects: resume.projects,
+  };
+  const jobForTailoring = {
+    company_name: jobListing.company_name,
+    position_title: jobListing.position_title,
+    description: jobListing.description,
+    location: jobListing.location,
+    keywords: jobListing.keywords,
+    work_location: jobListing.work_location,
+    employment_type: jobListing.employment_type,
+  };
   const start = Date.now();
   console.log(
     `[TAILOR][TRY] ${selectedConfig.model} | STEP: Tailoring resume content | Subscription: ${isPro ? 'PRO' : 'FREE'}`
@@ -73,13 +90,13 @@ export async function tailorResumeToJob(
         maxRetries: 0,
         system: `
 
-You are ResumeLM, an advanced AI resume transformer. Rewrite the resume so it is ATS-friendly and tightly aligned to the job description—without adding new facts or inventing experience.
+You are ResumeLM. Rewrite the resume so it is ATS-friendly and tightly aligned to the job description—without adding new facts or inventing experience.
 
 Guidelines:
 - Integrate job-specific terminology and reorder content to surface the most relevant experience first. Mirror the job's vocabulary when it is factual.
-- Use STAR reasoning internally but write each bullet as a single, natural resume bullet. NEVER include labels like "Situation", "Task", "Action", "Result", "Context", or "Outcome" in the output.
+- Write each bullet as one natural, concise resume bullet. Never include reasoning labels or commentary in the output.
 - Lead bullets with strong action verbs, keep them concise, and anchor claims with concrete, job-relevant metrics.
-- Enrich tech details with versions/frameworks when present in the source; do not fabricate tools or versions.
+- Preserve factual technologies and versions when present; do not fabricate them.
 - Preserve chronology and factual accuracy; if something is missing in the resume, do not invent it—map to the closest truthful concept instead.
 - Remove any internal notes/annotations; final output should be clean, professional resume content only.
 
@@ -88,10 +105,10 @@ Your task: produce a polished, tailored resume that meets the schema exactly and
         `,
         prompt: `
     This is the Resume:
-    ${JSON.stringify(resume, null, 2)}
+    ${JSON.stringify(resumeForTailoring)}
     
     This is the Job Description:
-    ${JSON.stringify(jobListing, null, 2)}
+    ${JSON.stringify(jobForTailoring)}
     `,
       }));
 

--- a/src/utils/actions/profiles/ai.ts
+++ b/src/utils/actions/profiles/ai.ts
@@ -35,6 +35,7 @@ async function runTrackedAIRequest<T extends { usage?: LanguageModelUsage }>(
       usageEventId,
       status: 'failed',
       errorCode: error instanceof Error ? error.message : 'ai_request_failed',
+      error,
     });
     throw error;
   }

--- a/src/utils/actions/resumes/actions.ts
+++ b/src/utils/actions/resumes/actions.ts
@@ -88,6 +88,7 @@ async function runTrackedAIRequest<T extends { usage?: LanguageModelUsage }>(
       usageEventId,
       status: 'failed',
       errorCode: error instanceof Error ? error.message : 'ai_request_failed',
+      error,
     });
     throw error;
   }
@@ -441,6 +442,7 @@ export async function createTailoredResume(
   await captureServerAnalyticsEvent({
     distinctId: user.id,
     event: AnalyticsEvents.ResumeTailored,
+    insertId: `${user.id}:${data.id}:${AnalyticsEvents.ResumeTailored}`,
     properties: {
       ...(await getSubscriptionAnalyticsProperties(supabase, user.id)),
       resume_type: "tailored",
@@ -580,7 +582,10 @@ export async function generateResumeScore(
 
   try {
     let prompt = `
-    Generate a comprehensive score for this resume: ${JSON.stringify(resumeForScoring)}
+    Generate a concise, actionable score for this resume: ${JSON.stringify(resumeForScoring)}
+
+    Return compact JSON. Keep every reason to one sentence of 20 words or fewer.
+    Limit overallImprovements and jobSpecificImprovements to five items each.
     
     MUST include a 'miscellaneous' field with 2-3 metrics following this format:
     {
@@ -636,7 +641,7 @@ export async function generateResumeScore(
       `;
     }
 
-    const { object } = await runTrackedAIRequest({
+      const { object } = await runTrackedAIRequest({
       route: 'actions.resumes.generateResumeScore',
       userId: id,
       isPro,
@@ -646,6 +651,7 @@ export async function generateResumeScore(
       maxRetries: 0,
       experimental_telemetry: telemetry,
       schema: resumeScoreSchema,
+      maxTokens: 2200,
       prompt
     }));
 

--- a/src/utils/actions/resumes/ai.ts
+++ b/src/utils/actions/resumes/ai.ts
@@ -49,6 +49,7 @@ async function runTrackedAIRequest<T extends { usage?: LanguageModelUsage }>(
       usageEventId,
       status: 'failed',
       errorCode: error instanceof Error ? error.message : 'ai_request_failed',
+      error,
     });
     throw error;
   }

--- a/supabase/migrations/20260830001920_entitlement_activation_claims.sql
+++ b/supabase/migrations/20260830001920_entitlement_activation_claims.sql
@@ -1,0 +1,12 @@
+CREATE TABLE IF NOT EXISTS public.stripe_entitlement_activations (
+  stripe_subscription_id text PRIMARY KEY,
+  user_id uuid NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+  first_activated_at timestamp with time zone NOT NULL DEFAULT timezone('utc'::text, now())
+);
+
+ALTER TABLE public.stripe_entitlement_activations ENABLE ROW LEVEL SECURITY;
+REVOKE ALL ON TABLE public.stripe_entitlement_activations FROM anon, authenticated;
+GRANT ALL ON TABLE public.stripe_entitlement_activations TO service_role;
+
+COMMENT ON TABLE public.stripe_entitlement_activations IS
+  'One service-owned entitlement activation claim per Stripe subscription lifecycle.';

--- a/supabase/migrations/20260830002001_add_entitlement_activation_user_index.sql
+++ b/supabase/migrations/20260830002001_add_entitlement_activation_user_index.sql
@@ -1,0 +1,2 @@
+CREATE INDEX IF NOT EXISTS stripe_entitlement_activations_user_id_idx
+  ON public.stripe_entitlement_activations (user_id);


### PR DESCRIPTION
## What changed
- stop successful AI requests from waiting on PostHog and first-success analytics
- add bounded AI failure categories/status/retryability to `ai_request_failed`
- enable PostHog browser exceptions and Next.js server request-error capture
- add editor analytics markers for rage-click diagnosis
- keep Stripe/Supabase lifecycle events on canonical Supabase user identity

## Validation
- typecheck
- lint
- 110 tests
- production build
- React Doctor changed-scope scan: no issues introduced